### PR TITLE
Add AppDrawer and register new routes

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:table_calendar/table_calendar.dart';
+import 'package:bugbear_app/features/common/app_drawer.dart';
 
 import '../models/calendar_event.dart';
 import '../dialogs/edit_training_day_dialog.dart';
@@ -76,6 +77,7 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent>
 
     return Scaffold(
       appBar: AppBar(title: const Text('Dein Trainingskalender')),
+      drawer: const AppDrawer(),
       body: Column(
         children: [
           TableCalendar<CalendarEvent>(

--- a/lib/features/common/app_drawer.dart
+++ b/lib/features/common/app_drawer.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:bugbear_app/features/training/screens/phase_selection_screen.dart';
+
+/// A global navigation drawer used across the app.
+class AppDrawer extends StatelessWidget {
+  const AppDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(color: Colors.blueGrey),
+              child: Text('Menü', style: TextStyle(fontSize: 24, color: Colors.white)),
+            ),
+            ListTile(
+              leading: const Icon(Icons.dashboard),
+              title: const Text('Dashboard'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).pushNamed('/dashboard');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.fitness_center),
+              title: const Text('Training'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).pushNamed('/training');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.calendar_today),
+              title: const Text('Kalender'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).pushNamed('/calendar');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Einstellungen'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).pushNamed('/settings');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.playlist_play),
+              title: const Text('Phase auswählen'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const PhaseSelectionScreen()),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -1,8 +1,7 @@
 // lib/features/common/dashboard_screen.dart
 
 import 'package:flutter/material.dart';
-import 'package:bugbear_app/features/training/training_screen.dart';
-import 'package:bugbear_app/features/calendar/screens/calendar_screen.dart';
+import 'package:bugbear_app/features/common/app_drawer.dart';
 
 /// DashboardScreen
 ///
@@ -14,6 +13,7 @@ class DashboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
+      drawer: const AppDrawer(),
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -21,18 +21,12 @@ class DashboardScreen extends StatelessWidget {
             const Text('Willkommen im Dashboard!'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const TrainingScreen()),
-              ),
+              onPressed: () => Navigator.pushNamed(context, '/training'),
               child: const Text('Zum Training'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const CalendarScreen()),
-              ),
+              onPressed: () => Navigator.pushNamed(context, '/calendar'),
               child: const Text('Zum Kalender'),
             ),
           ],

--- a/lib/features/onboarding/profile/settings_screen.dart
+++ b/lib/features/onboarding/profile/settings_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bugbear_app/features/onboarding/services/auth_service.dart';
+import 'package:bugbear_app/features/common/app_drawer.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -23,6 +24,7 @@ class SettingsScreenState extends State<SettingsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Einstellungen')),
+      drawer: const AppDrawer(),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/features/training/screens/phase_selection_screen.dart
+++ b/lib/features/training/screens/phase_selection_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:bugbear_app/features/training/services/exercise_repository.dart';
 import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
+import 'package:bugbear_app/features/common/app_drawer.dart';
 
 class PhaseSelectionScreen extends StatelessWidget {
   const PhaseSelectionScreen({super.key});
@@ -11,6 +12,7 @@ class PhaseSelectionScreen extends StatelessWidget {
     final phases = context.read<ExerciseRepository>().phaseIds;
     return Scaffold(
       appBar: AppBar(title: const Text('Phase auswählen')),
+      drawer: const AppDrawer(),
       body: ListView.builder(
         itemCount: phases.length,
         itemBuilder: (ctx, i) {

--- a/lib/features/training/training_screen.dart
+++ b/lib/features/training/training_screen.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
 import 'package:bugbear_app/features/training/widgets/training_header.dart';
-import 'package:bugbear_app/features/training/widgets/training_drawer.dart';
+import 'package:bugbear_app/features/common/app_drawer.dart';
 import 'package:bugbear_app/features/training/widgets/progress_row.dart';
 import 'package:bugbear_app/features/training/widgets/exercise_canvas.dart';
 import 'package:bugbear_app/features/training/widgets/control_button_row.dart';
@@ -20,7 +20,7 @@ class TrainingScreen extends StatelessWidget {
     final current = exercises[idx];
 
     return Scaffold(
-      drawer: const TrainingDrawer(), // neuer Drawer
+      drawer: const AppDrawer(),
       appBar: TrainingHeader(
         phaseName: 'Phase ${state.phaseId}',
         onHelpPressed: () {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,8 @@ import 'package:bugbear_app/features/onboarding/screens/register_screen.dart';
 import 'package:bugbear_app/features/onboarding/screens/role_selection_screen.dart';
 import 'package:bugbear_app/features/common/dashboard_screen.dart';
 import 'package:bugbear_app/features/onboarding/profile/settings_screen.dart';
+import 'package:bugbear_app/features/training/training_screen.dart';
+import 'package:bugbear_app/features/calendar/screens/calendar_screen.dart';
 
 import 'package:bugbear_app/features/training/models/session_state.dart';
 import 'package:bugbear_app/features/training/models/session_state_adapter.dart';
@@ -127,6 +129,8 @@ class MyApp extends StatelessWidget {
           '/register': (c) => const RegisterScreen(),
           '/select-role': (c) => const RoleSelectionScreen(),
           '/dashboard': (c) => const DashboardScreen(),
+          '/training': (c) => const TrainingScreen(),
+          '/calendar': (c) => const CalendarScreen(),
           '/settings': (c) => const SettingsScreen(),
         },
       ),


### PR DESCRIPTION
## Summary
- add new `AppDrawer` widget providing global navigation
- register named routes for training and calendar
- update dashboard buttons to use named routes
- use `AppDrawer` across screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853296ecad4832db21769bb4f497dbb