### PR TITLE
Fix quiz screen scaffold constant

### DIFF
--- a/lib/features/quiz/screens/quiz_screen.dart
+++ b/lib/features/quiz/screens/quiz_screen.dart
@@ -33,9 +33,9 @@ class _QuizContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final notifier = context.watch<QuizNotifier>();
     if (notifier.questions.isEmpty) {
-      return const Scaffold(
-        appBar: AppBar(title: Text('Quiz')),
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        appBar: AppBar(title: const Text('Quiz')),
+        body: const Center(child: CircularProgressIndicator()),
       );
     }
 


### PR DESCRIPTION
## Summary
- remove const wrapper from `_QuizContent.build`'s `Scaffold`
- keep inner widgets constant

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341ad0450832d8f2d8d15e570e1df