### PR TITLE
Remove const from Scaffold

### DIFF
--- a/lib/features/quiz/screens/reflex_profile_screen.dart
+++ b/lib/features/quiz/screens/reflex_profile_screen.dart
@@ -15,7 +15,7 @@ class ReflexProfileScreen extends StatelessWidget {
       future: QuizService(locale).loadCategories(),
       builder: (ctx, snap) {
         if (!snap.hasData) {
-          return const Scaffold(
+          return Scaffold(
             appBar: AppBar(title: Text('Profil')),
             body: Center(child: CircularProgressIndicator()),
           );


### PR DESCRIPTION
## Summary
- fix ReflexProfileScreen to return non-const Scaffold when there is no data

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341adde4c832daafa670a9130a02a