### PR TITLE
Fix constant Scaffold usage in SavedProfileScreen

### DIFF
--- a/lib/features/quiz/screens/saved_profile_screen.dart
+++ b/lib/features/quiz/screens/saved_profile_screen.dart
@@ -14,14 +14,14 @@ class SavedProfileScreen extends StatelessWidget {
       future: service.load(),
       builder: (ctx, snap) {
         if (!snap.hasData) {
-          return const Scaffold(
+          return Scaffold(
             appBar: AppBar(title: Text('Reflexprofil')),
             body: Center(child: CircularProgressIndicator()),
           );
         }
         final profile = snap.data;
         if (profile == null) {
-          return const Scaffold(
+          return Scaffold(
             appBar: AppBar(title: Text('Reflexprofil')),
             body: Center(child: Text('Kein Profil gespeichert.')),
           );


### PR DESCRIPTION
## Summary
- remove `const` before `Scaffold` when no snapshot data
- remove `const` before `Scaffold` when no saved profile

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341adfb34832d80d984b20f3bd755