### PR TITLE
Fix EditTrainingDayDialog save handling

### DIFF
--- a/lib/features/calendar/dialogs/edit_training_day_dialog.dart
+++ b/lib/features/calendar/dialogs/edit_training_day_dialog.dart
@@ -116,12 +116,14 @@ class _EditTrainingDayDialogState
                 notes: _notes,
               );
 
-              await context
-                  .read<CalendarService>()
-                  .saveTrainingDay(updated);
-              await context
-                  .read<CalendarNotifier>()
-                  .loadMonth(context.read<CalendarNotifier>().focusedDay);
+              final CalendarService service = context.read<CalendarService>();
+              final CalendarNotifier notifier = context.read<CalendarNotifier>();
+
+              await service.saveTrainingDay(updated);
+              if (!mounted) return;
+
+              await notifier.loadMonth(notifier.focusedDay);
+              if (!mounted) return;
 
               Navigator.of(context).pop(updated);
             }


### PR DESCRIPTION
## Summary
- ensure CalendarService and CalendarNotifier are read before await
- reload month and pop dialog only when mounted

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341af9ab4832d8cf807c09587ebb9