### PR TITLE
Fix highlight alpha

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -176,7 +176,9 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent>
     return Container(
       margin: const EdgeInsets.all(4),
       decoration: BoxDecoration(
-        color: sel ? scheduledColor.withOpacity(0.2) : null,
+        color: sel
+            ? scheduledColor.withAlpha((0.2 * 255).round())
+            : null,
         border: isToday ? Border.all(color: scheduledColor, width: 2) : null,
         borderRadius: BorderRadius.circular(8),
       ),


### PR DESCRIPTION
## Summary
- adjust day cell color to use `withAlpha`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341b297e4832d865b60fdcd635656