### PR TITLE
Implement reflex quiz and profile screens

### DIFF
--- a/lib/features/calendar/dialogs/edit_training_day_dialog.dart
+++ b/lib/features/calendar/dialogs/edit_training_day_dialog.dart
@@ -119,10 +119,11 @@ class _EditTrainingDayDialogState
               await context
                   .read<CalendarService>()
                   .saveTrainingDay(updated);
+              if (!mounted) return;
               await context
                   .read<CalendarNotifier>()
                   .loadMonth(context.read<CalendarNotifier>().focusedDay);
-
+              if (!mounted) return;
               Navigator.of(context).pop(updated);
             }
           },

--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -176,7 +176,7 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent>
     return Container(
       margin: const EdgeInsets.all(4),
       decoration: BoxDecoration(
-        color: sel ? scheduledColor.withOpacity(0.2) : null,
+        color: sel ? scheduledColor.withAlpha((0.2 * 255).round()) : null,
         border: isToday ? Border.all(color: scheduledColor, width: 2) : null,
         borderRadius: BorderRadius.circular(8),
       ),

--- a/lib/features/common/splash_screen.dart
+++ b/lib/features/common/splash_screen.dart
@@ -26,6 +26,8 @@ class _SplashScreenState extends State<SplashScreen> {
     final loggedIn = await _secureStorage.isLoggedIn;
     final firebaseUser = FirebaseAuth.instance.currentUser;
 
+    if (!mounted) return;
+
     if (loggedIn && firebaseUser != null) {
       Navigator.pushReplacementNamed(context, '/dashboard');
     } else {

--- a/lib/features/quiz/models/quiz_question.dart
+++ b/lib/features/quiz/models/quiz_question.dart
@@ -1,0 +1,19 @@
+class QuizQuestion {
+  final String id;
+  final Map<String, String> text;
+  final List<String> categoryIds;
+
+  QuizQuestion({
+    required this.id,
+    required this.text,
+    required this.categoryIds,
+  });
+
+  factory QuizQuestion.fromJson(Map<String, dynamic> json) {
+    return QuizQuestion(
+      id: json['id'] as String,
+      text: Map<String, String>.from(json['text'] as Map),
+      categoryIds: List<String>.from(json['categoryIds'] as List),
+    );
+  }
+}

--- a/lib/features/quiz/models/reflex_category.dart
+++ b/lib/features/quiz/models/reflex_category.dart
@@ -1,0 +1,13 @@
+class ReflexCategory {
+  final String id;
+  final String name;
+
+  ReflexCategory({required this.id, required this.name});
+
+  factory ReflexCategory.fromJson(Map<String, dynamic> json) {
+    return ReflexCategory(
+      id: json['id'] as String,
+      name: json['name'] as String,
+    );
+  }
+}

--- a/lib/features/quiz/models/reflex_profile.dart
+++ b/lib/features/quiz/models/reflex_profile.dart
@@ -1,0 +1,20 @@
+class ReflexProfile {
+  final Map<String, double> scores;
+  final DateTime createdAt;
+
+  ReflexProfile({required this.scores, required this.createdAt});
+
+  factory ReflexProfile.fromJson(Map<String, dynamic> json) {
+    final raw = Map<String, dynamic>.from(json['scores'] as Map);
+    final scores = raw.map((k, v) => MapEntry(k, (v as num).toDouble()));
+    return ReflexProfile(
+      scores: scores,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'scores': scores,
+        'createdAt': createdAt.toIso8601String(),
+      };
+}

--- a/lib/features/quiz/models/reflex_profile_adapter.dart
+++ b/lib/features/quiz/models/reflex_profile_adapter.dart
@@ -1,0 +1,29 @@
+import 'package:hive/hive.dart';
+import 'reflex_profile.dart';
+
+class ReflexProfileAdapter extends TypeAdapter<ReflexProfile> {
+  @override
+  final int typeId = 3;
+
+  @override
+  ReflexProfile read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    final Map map = fields[0] as Map;
+    final scores = map.map((k, v) => MapEntry(k as String, (v as num).toDouble()));
+    final created = fields[1] as DateTime;
+    return ReflexProfile(scores: scores, createdAt: created);
+  }
+
+  @override
+  void write(BinaryWriter writer, ReflexProfile obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.scores)
+      ..writeByte(1)
+      ..write(obj.createdAt);
+  }
+}

--- a/lib/features/quiz/notifier/quiz_notifier.dart
+++ b/lib/features/quiz/notifier/quiz_notifier.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import '../models/quiz_question.dart';
+import '../models/reflex_category.dart';
+import '../models/reflex_profile.dart';
+import '../services/quiz_service.dart';
+import '../services/reflex_profile_service.dart';
+
+class QuizNotifier extends ChangeNotifier {
+  final QuizService _service;
+  final ReflexProfileService _profileService;
+
+  List<QuizQuestion> _questions = [];
+  List<ReflexCategory> _categories = [];
+  final Map<String, bool> _answers = {};
+  int _index = 0;
+
+  QuizNotifier(this._service, this._profileService);
+
+  List<QuizQuestion> get questions => _questions;
+  List<ReflexCategory> get categories => _categories;
+  int get index => _index;
+
+  Future<void> load() async {
+    _questions = await _service.loadQuestions();
+    _categories = await _service.loadCategories();
+    _index = 0;
+    _answers.clear();
+    notifyListeners();
+  }
+
+  bool? get currentAnswer => _answers[_questions[_index].id];
+
+  void answer(bool value) {
+    _answers[_questions[_index].id] = value;
+    notifyListeners();
+  }
+
+  void next() {
+    if (_index < _questions.length - 1) {
+      _index++;
+      notifyListeners();
+    }
+  }
+
+  void previous() {
+    if (_index > 0) {
+      _index--;
+      notifyListeners();
+    }
+  }
+
+  bool get isLast => _index == _questions.length - 1;
+
+  Map<String, double> _calculateScores() {
+    final Map<String, int> totals = {};
+    final Map<String, int> yes = {};
+    for (var q in _questions) {
+      for (var cat in q.categoryIds) {
+        totals[cat] = (totals[cat] ?? 0) + 1;
+        if (_answers[q.id] == true) {
+          yes[cat] = (yes[cat] ?? 0) + 1;
+        }
+      }
+    }
+    final Map<String, double> result = {};
+    for (var cat in totals.keys) {
+      final y = yes[cat] ?? 0;
+      result[cat] = totals[cat]! == 0 ? 0 : y / totals[cat]! * 100;
+    }
+    return result;
+  }
+
+  ReflexProfile buildProfile() {
+    return ReflexProfile(
+      scores: _calculateScores(),
+      createdAt: DateTime.now(),
+    );
+  }
+
+  Future<void> saveProfile() async {
+    final profile = buildProfile();
+    await _profileService.save(profile);
+  }
+}

--- a/lib/features/quiz/screens/quiz_screen.dart
+++ b/lib/features/quiz/screens/quiz_screen.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:bugbear_app/widgets/app_drawer.dart';
+import '../services/quiz_service.dart';
+import '../services/reflex_profile_service.dart';
+import '../notifier/quiz_notifier.dart';
+import 'reflex_profile_screen.dart';
+
+class QuizScreen extends StatelessWidget {
+  const QuizScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final locale = Localizations.localeOf(context).languageCode;
+    return ChangeNotifierProvider<QuizNotifier>(
+      create: (_) {
+        final notifier = QuizNotifier(
+          QuizService(locale),
+          ReflexProfileService(),
+        );
+        notifier.load();
+        return notifier;
+      },
+      child: const _QuizContent(),
+    );
+  }
+}
+
+class _QuizContent extends StatelessWidget {
+  const _QuizContent();
+
+  @override
+  Widget build(BuildContext context) {
+    final notifier = context.watch<QuizNotifier>();
+    if (notifier.questions.isEmpty) {
+        return const Scaffold(
+          appBar: const AppBar(title: const Text('Quiz')),
+          body: const Center(child: const CircularProgressIndicator()),
+        );
+    }
+
+    final question = notifier.questions[notifier.index];
+    final lang = Localizations.localeOf(context).languageCode;
+    final text = question.text[lang] ?? question.text.values.first;
+
+    return Scaffold(
+      drawer: const AppDrawer(),
+      appBar: AppBar(title: const Text('Quiz')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Frage ${notifier.index + 1} von ${notifier.questions.length}'),
+            const SizedBox(height: 12),
+            Text(text, style: const TextStyle(fontSize: 18)),
+            const Spacer(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ElevatedButton(
+                  onPressed: () => notifier.answer(true),
+                  child: const Text('Ja'),
+                ),
+                const SizedBox(width: 16),
+                ElevatedButton(
+                  onPressed: () => notifier.answer(false),
+                  child: const Text('Nein'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                if (notifier.index > 0)
+                  OutlinedButton(
+                    onPressed: notifier.previous,
+                    child: const Text('Zurück'),
+                  ),
+                ElevatedButton(
+                  onPressed: notifier.isLast
+                      ? () => _finish(context)
+                      : notifier.next,
+                  child: Text(notifier.isLast ? 'Fertig' : 'Weiter'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _finish(BuildContext context) async {
+    final notifier = context.read<QuizNotifier>();
+    final save = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Ergebnis speichern?'),
+        content: const Text('Möchtest du dein Profil speichern?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Nur anzeigen'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Speichern'),
+          ),
+        ],
+      ),
+    );
+
+    final profile = notifier.buildProfile();
+    if (save == true) {
+      await notifier.saveProfile();
+    }
+    if (context.mounted) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => ReflexProfileScreen(profile: profile),
+        ),
+      );
+    }
+  }
+}

--- a/lib/features/quiz/screens/reflex_profile_screen.dart
+++ b/lib/features/quiz/screens/reflex_profile_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:bugbear_app/widgets/app_drawer.dart';
+import '../models/reflex_profile.dart';
+import '../services/quiz_service.dart';
+import '../models/reflex_category.dart';
+
+class ReflexProfileScreen extends StatelessWidget {
+  final ReflexProfile profile;
+  const ReflexProfileScreen({super.key, required this.profile});
+
+  @override
+  Widget build(BuildContext context) {
+    final locale = Localizations.localeOf(context).languageCode;
+    return FutureBuilder<List<ReflexCategory>>(
+      future: QuizService(locale).loadCategories(),
+      builder: (ctx, snap) {
+        if (!snap.hasData) {
+          return const Scaffold(
+            appBar: AppBar(title: const Text('Profil')),
+            body: const Center(child: CircularProgressIndicator()),
+          );
+        }
+        final names = {for (var c in snap.data!) c.id: c.name};
+        return Scaffold(
+          drawer: const AppDrawer(),
+          appBar: AppBar(title: const Text('Reflexprofil')),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: profile.scores.entries.map((e) {
+              final name = names[e.key] ?? e.key;
+              final percent = e.value.toStringAsFixed(0);
+              return ListTile(
+                title: Text(name),
+                trailing: Text('$percent %'),
+              );
+            }).toList(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/quiz/screens/saved_profile_screen.dart
+++ b/lib/features/quiz/screens/saved_profile_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/reflex_profile_service.dart';
+import '../models/reflex_profile.dart';
+import 'reflex_profile_screen.dart';
+
+class SavedProfileScreen extends StatelessWidget {
+  const SavedProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.read<ReflexProfileService>();
+    return FutureBuilder<ReflexProfile?>(
+      future: service.load(),
+      builder: (ctx, snap) {
+        if (!snap.hasData) {
+          return const Scaffold(
+            appBar: AppBar(title: const Text('Reflexprofil')),
+            body: const Center(child: CircularProgressIndicator()),
+          );
+        }
+        final profile = snap.data;
+        if (profile == null) {
+          return const Scaffold(
+            appBar: AppBar(title: const Text('Reflexprofil')),
+            body: const Center(child: Text('Kein Profil gespeichert.')),
+          );
+        }
+        return ReflexProfileScreen(profile: profile);
+      },
+    );
+  }
+}

--- a/lib/features/quiz/services/quiz_service.dart
+++ b/lib/features/quiz/services/quiz_service.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import '../models/quiz_question.dart';
+import '../models/reflex_category.dart';
+
+class QuizService {
+  final String languageCode;
+  QuizService(this.languageCode);
+
+  Future<List<QuizQuestion>> loadQuestions() async {
+    final file = languageCode.startsWith('de')
+        ? 'assets/quiz_questions_de.json'
+        : 'assets/quiz_questions_en.json';
+    final str = await rootBundle.loadString(file);
+    final list = json.decode(str) as List<dynamic>;
+    return list
+        .map((e) => QuizQuestion.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<ReflexCategory>> loadCategories() async {
+    final file = languageCode.startsWith('de')
+        ? 'assets/reflex_categories_de.json'
+        : 'assets/reflex_categories_en.json';
+    final str = await rootBundle.loadString(file);
+    final list = json.decode(str) as List<dynamic>;
+    return list
+        .map((e) => ReflexCategory.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/features/quiz/services/reflex_profile_service.dart
+++ b/lib/features/quiz/services/reflex_profile_service.dart
@@ -1,0 +1,21 @@
+import 'package:hive/hive.dart';
+import '../models/reflex_profile.dart';
+
+class ReflexProfileService {
+  static const String _boxName = 'reflex_profile';
+  static const String _key = 'profile';
+
+  Box<ReflexProfile> get _box => Hive.box<ReflexProfile>(_boxName);
+
+  Future<ReflexProfile?> load() async {
+    return _box.get(_key);
+  }
+
+  Future<void> save(ReflexProfile profile) async {
+    await _box.put(_key, profile);
+  }
+
+  Future<void> clear() async {
+    await _box.delete(_key);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,11 @@ import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
+import 'package:bugbear_app/features/quiz/models/reflex_profile.dart';
+import 'package:bugbear_app/features/quiz/models/reflex_profile_adapter.dart';
+import 'package:bugbear_app/features/quiz/screens/quiz_screen.dart';
+import 'package:bugbear_app/features/quiz/screens/saved_profile_screen.dart';
+import 'package:bugbear_app/features/quiz/services/reflex_profile_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -45,6 +50,10 @@ Future<void> main() async {
   // CalendarEvent persistence
   Hive.registerAdapter(CalendarEventAdapter());
   await Hive.openBox<CalendarEvent>('calendar_events');
+
+  // ReflexProfile persistence
+  Hive.registerAdapter(ReflexProfileAdapter());
+  await Hive.openBox<ReflexProfile>('reflex_profile');
 
   final sessionRepository = SessionRepository();
   final saved = await sessionRepository.load();
@@ -100,6 +109,9 @@ class MyApp extends StatelessWidget {
         Provider<CalendarService>(
           create: (_) => CalendarService(),
         ),
+        Provider<ReflexProfileService>(
+          create: (_) => ReflexProfileService(),
+        ),
         Provider<ExerciseRepository>(
           create: (_) => ExerciseRepository(),
         ),
@@ -132,6 +144,8 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
+          '/quiz': (c) => const QuizScreen(),
+          '/profile': (c) => const SavedProfileScreen(),
         },
       ),
     );

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -43,6 +43,22 @@ class AppDrawer extends StatelessWidget {
               },
             ),
             ListTile(
+              leading: const Icon(Icons.quiz),
+              title: const Text('Reflexe-Quiz'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, '/quiz');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.person),
+              title: const Text('Reflexprofil'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, '/profile');
+              },
+            ),
+            ListTile(
               leading: const Icon(Icons.settings),
               title: const Text('Einstellungen'),
               onTap: () {


### PR DESCRIPTION
## Summary
- create quiz models and hive adapter for reflex profile
- add quiz logic with `QuizNotifier`
- implement quiz, profile and saved profile screens
- add reflex profile persistence and routes
- register hive adapter in `main.dart` and expose new menu entries
- fix analyzer issues in quiz/profile screens and context usage

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853370e3168832db0927c83fe2c597f