### PR TITLE
Fix use_build_context and const warnings

### DIFF
--- a/lib/features/calendar/dialogs/edit_training_day_dialog.dart
+++ b/lib/features/calendar/dialogs/edit_training_day_dialog.dart
@@ -119,13 +119,14 @@ class _EditTrainingDayDialogState
               final CalendarService service = context.read<CalendarService>();
               final CalendarNotifier notifier = context.read<CalendarNotifier>();
 
+              final navigator = Navigator.of(context);
               await service.saveTrainingDay(updated);
               if (!mounted) return;
 
               await notifier.loadMonth(notifier.focusedDay);
               if (!mounted) return;
 
-              Navigator.of(context).pop(updated);
+              navigator.pop(updated);
             }
           },
           child: const Text('Speichern'),

--- a/lib/features/common/splash_screen.dart
+++ b/lib/features/common/splash_screen.dart
@@ -26,6 +26,7 @@ class _SplashScreenState extends State<SplashScreen> {
     final loggedIn = await _secureStorage.isLoggedIn;
     final firebaseUser = FirebaseAuth.instance.currentUser;
 
+    if (!mounted) return;
     if (loggedIn && firebaseUser != null) {
       Navigator.pushReplacementNamed(context, '/dashboard');
     } else {

--- a/lib/features/quiz/screens/reflex_profile_screen.dart
+++ b/lib/features/quiz/screens/reflex_profile_screen.dart
@@ -16,8 +16,8 @@ class ReflexProfileScreen extends StatelessWidget {
       builder: (ctx, snap) {
         if (!snap.hasData) {
           return Scaffold(
-            appBar: AppBar(title: Text('Profil')),
-            body: Center(child: CircularProgressIndicator()),
+            appBar: const AppBar(title: Text('Profil')),
+            body: const Center(child: CircularProgressIndicator()),
           );
         }
         final names = {for (var c in snap.data!) c.id: c.name};

--- a/lib/features/quiz/screens/saved_profile_screen.dart
+++ b/lib/features/quiz/screens/saved_profile_screen.dart
@@ -15,15 +15,15 @@ class SavedProfileScreen extends StatelessWidget {
       builder: (ctx, snap) {
         if (!snap.hasData) {
           return Scaffold(
-            appBar: AppBar(title: Text('Reflexprofil')),
-            body: Center(child: CircularProgressIndicator()),
+            appBar: const AppBar(title: Text('Reflexprofil')),
+            body: const Center(child: CircularProgressIndicator()),
           );
         }
         final profile = snap.data;
         if (profile == null) {
           return Scaffold(
-            appBar: AppBar(title: Text('Reflexprofil')),
-            body: Center(child: Text('Kein Profil gespeichert.')),
+            appBar: const AppBar(title: Text('Reflexprofil')),
+            body: const Center(child: Text('Kein Profil gespeichert.')),
           );
         }
         return ReflexProfileScreen(profile: profile);


### PR DESCRIPTION
## Summary
- prevent using BuildContext after async gaps in `SplashScreen`
- capture Navigator before async gaps in `EditTrainingDayDialog`
- mark constant widgets in `ReflexProfileScreen` and `SavedProfileScreen`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535cf4becc832d9f4968e4a8ddb7a7