### PR TITLE
Fix const constructor errors

### DIFF
--- a/lib/features/quiz/screens/reflex_profile_screen.dart
+++ b/lib/features/quiz/screens/reflex_profile_screen.dart
@@ -16,7 +16,7 @@ class ReflexProfileScreen extends StatelessWidget {
       builder: (ctx, snap) {
         if (!snap.hasData) {
           return Scaffold(
-            appBar: const AppBar(title: Text('Profil')),
+            appBar: AppBar(title: const Text('Profil')),
             body: const Center(child: CircularProgressIndicator()),
           );
         }

--- a/lib/features/quiz/screens/saved_profile_screen.dart
+++ b/lib/features/quiz/screens/saved_profile_screen.dart
@@ -15,14 +15,14 @@ class SavedProfileScreen extends StatelessWidget {
       builder: (ctx, snap) {
         if (!snap.hasData) {
           return Scaffold(
-            appBar: const AppBar(title: Text('Reflexprofil')),
+            appBar: AppBar(title: const Text('Reflexprofil')),
             body: const Center(child: CircularProgressIndicator()),
           );
         }
         final profile = snap.data;
         if (profile == null) {
           return Scaffold(
-            appBar: const AppBar(title: Text('Reflexprofil')),
+            appBar: AppBar(title: const Text('Reflexprofil')),
             body: const Center(child: Text('Kein Profil gespeichert.')),
           );
         }


### PR DESCRIPTION
## Summary
- remove `const` keyword where `AppBar` is not const

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535f13befc832db5b8a1c4cdaea242