### PR TITLE
Fix broken references after removing quiz

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,11 +29,6 @@ import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
-import 'package:bugbear_app/features/quiz/models/reflex_profile.dart';
-import 'package:bugbear_app/features/quiz/models/reflex_profile_adapter.dart';
-import 'package:bugbear_app/features/quiz/screens/quiz_screen.dart';
-import 'package:bugbear_app/features/quiz/screens/saved_profile_screen.dart';
-import 'package:bugbear_app/features/quiz/services/reflex_profile_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -51,9 +46,6 @@ Future<void> main() async {
   Hive.registerAdapter(CalendarEventAdapter());
   await Hive.openBox<CalendarEvent>('calendar_events');
 
-  // ReflexProfile persistence
-  Hive.registerAdapter(ReflexProfileAdapter());
-  await Hive.openBox<ReflexProfile>('reflex_profile');
 
   final sessionRepository = SessionRepository();
   final saved = await sessionRepository.load();
@@ -109,9 +101,6 @@ class MyApp extends StatelessWidget {
         Provider<CalendarService>(
           create: (_) => CalendarService(),
         ),
-        Provider<ReflexProfileService>(
-          create: (_) => ReflexProfileService(),
-        ),
         Provider<ExerciseRepository>(
           create: (_) => ExerciseRepository(),
         ),
@@ -144,8 +133,6 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
-          '/quiz': (c) => const QuizScreen(),
-          '/profile': (c) => const SavedProfileScreen(),
         },
       ),
     );

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -43,22 +43,6 @@ class AppDrawer extends StatelessWidget {
               },
             ),
             ListTile(
-              leading: const Icon(Icons.quiz),
-              title: const Text('Reflexe-Quiz'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/quiz');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.person),
-              title: const Text('Reflexprofil'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/profile');
-              },
-            ),
-            ListTile(
               leading: const Icon(Icons.settings),
               title: const Text('Einstellungen'),
               onTap: () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,10 +55,6 @@ flutter:
   uses-material-design: true
 
   assets:
-    - assets/quiz_questions_de.json
-    - assets/quiz_questions_en.json
-    - assets/reflex_categories_de.json
-    - assets/reflex_categories_en.json
     - assets/images/
     - assets/sounds/
 


### PR DESCRIPTION
## Summary
- remove quiz asset references
- clean up quiz imports and hive setup
- drop quiz and profile routes
- remove quiz entries from the drawer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559e948ba4832da8cf49cd3655c8ee