### PR TITLE
Add questionnaire screens and menu route

### DIFF
--- a/lib/features/questionnaire/screens/language_selection_screen.dart
+++ b/lib/features/questionnaire/screens/language_selection_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Screen to choose the app language.
+class LanguageSelectionScreen extends StatelessWidget {
+  const LanguageSelectionScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sprache wählen')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('Deutsch'),
+            onTap: () => Navigator.pop(context, 'de'),
+          ),
+          ListTile(
+            title: const Text('English'),
+            onTap: () => Navigator.pop(context, 'en'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/questionnaire/screens/questionnaire_screen.dart
+++ b/lib/features/questionnaire/screens/questionnaire_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Main questionnaire screen.
+class QuestionnaireScreen extends StatelessWidget {
+  const QuestionnaireScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Fragebogen')),
+      body: const Center(
+        child: Text('Hier folgt der Fragebogen'),
+      ),
+    );
+  }
+}

--- a/lib/features/questionnaire/screens/result_screen.dart
+++ b/lib/features/questionnaire/screens/result_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Displays the questionnaire result to the user.
+class ResultScreen extends StatelessWidget {
+  const ResultScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ergebnis')),
+      body: const Center(
+        child: Text('Hier werden die Ergebnisse angezeigt'),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,9 @@ import 'package:bugbear_app/features/common/dashboard_screen.dart';
 import 'package:bugbear_app/features/onboarding/profile/settings_screen.dart';
 import 'package:bugbear_app/features/training/training_screen.dart';
 import 'package:bugbear_app/features/calendar/screens/calendar_screen.dart';
+import 'package:bugbear_app/features/questionnaire/screens/language_selection_screen.dart';
+import 'package:bugbear_app/features/questionnaire/screens/questionnaire_screen.dart';
+import 'package:bugbear_app/features/questionnaire/screens/result_screen.dart';
 
 import 'package:bugbear_app/features/training/models/session_state.dart';
 import 'package:bugbear_app/features/training/models/session_state_adapter.dart';
@@ -133,6 +136,9 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
+          '/select-language': (c) => const LanguageSelectionScreen(),
+          '/questionnaire': (c) => const QuestionnaireScreen(),
+          '/result': (c) => const ResultScreen(),
         },
       ),
     );

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -51,6 +51,14 @@ class AppDrawer extends StatelessWidget {
               },
             ),
             ListTile(
+              leading: const Icon(Icons.quiz),
+              title: const Text('Fragebogen'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, '/questionnaire');
+              },
+            ),
+            ListTile(
               leading: const Icon(Icons.playlist_play),
               title: const Text('Phase ausw\u00e4hlen'),
               onTap: () {


### PR DESCRIPTION
## Summary
- create placeholder screens for language selection, questionnaire, and results
- register routes for the new screens in `main.dart`
- add questionnaire entry in the application drawer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855a9f5caa4832d96ba51cef289a57c