### PR TITLE
Add reflex profile screens and Firestore support

### DIFF
--- a/lib/features/reflexe/models/reflex_profile.dart
+++ b/lib/features/reflexe/models/reflex_profile.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Holds yes/answered counts for a single reflex.
+class ReflexResult {
+  final int yesCount;
+  final int answeredCount;
+
+  ReflexResult({required this.yesCount, required this.answeredCount});
+
+  Map<String, dynamic> toMap() => {
+        'yes': yesCount,
+        'answered': answeredCount,
+      };
+
+  factory ReflexResult.fromMap(Map<String, dynamic> map) {
+    return ReflexResult(
+      yesCount: map['yes'] as int? ?? 0,
+      answeredCount: map['answered'] as int? ?? 0,
+    );
+  }
+}
+
+/// A stored reflex profile consisting of multiple reflex results.
+class ReflexProfile {
+  final String id;
+  final DateTime createdAt;
+  final Map<String, ReflexResult> results;
+
+  ReflexProfile({
+    required this.id,
+    required this.createdAt,
+    required this.results,
+  });
+
+  factory ReflexProfile.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    final resultMap = Map<String, dynamic>.from(data['results'] as Map);
+    final results = resultMap.map((key, value) =>
+        MapEntry(key, ReflexResult.fromMap(Map<String, dynamic>.from(value))));
+    final createdAt = (data['createdAt'] as Timestamp).toDate();
+    return ReflexProfile(id: doc.id, createdAt: createdAt, results: results);
+  }
+}

--- a/lib/features/reflexe/models/reflex_profile.dart
+++ b/lib/features/reflexe/models/reflex_profile.dart
@@ -1,3 +1,5 @@
+// lib/features/reflexe/models/reflex_profile.dart
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 /// Holds yes/answered counts for a single reflex.

--- a/lib/features/reflexe/screens/reflexe_profil.dart
+++ b/lib/features/reflexe/screens/reflexe_profil.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/reflex_profile.dart';
+import '../services/reflex_profile_service.dart';
+
+/// Screen displaying saved reflex profiles.
+class ReflexeProfilScreen extends StatelessWidget {
+  const ReflexeProfilScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gespeicherte Profile')),
+      body: FutureBuilder<List<ReflexProfile>>(
+        future: context.read<ReflexProfileService>().loadProfiles(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('Keine Profile gespeichert'));
+          }
+          final profiles = snapshot.data!;
+          final df = DateFormat.yMMMd();
+          return ListView.builder(
+            itemCount: profiles.length,
+            itemBuilder: (ctx, i) {
+              final profile = profiles[i];
+              return ExpansionTile(
+                title: Text(df.format(profile.createdAt)),
+                children: profile.results.entries
+                    .map(
+                      (e) => ListTile(
+                        title: Text(e.key),
+                        trailing: Text(
+                            '${e.value.yesCount}/${e.value.answeredCount}'),
+                      ),
+                    )
+                    .toList(),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/reflexe/screens/reflexe_profil.dart
+++ b/lib/features/reflexe/screens/reflexe_profil.dart
@@ -1,3 +1,5 @@
+// lib/features/reflexe/screens/reflexe_profil.dart
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';

--- a/lib/features/reflexe/screens/reflexe_profil_temp.dart
+++ b/lib/features/reflexe/screens/reflexe_profil_temp.dart
@@ -1,3 +1,5 @@
+// lib/features/reflexe/screens/reflexe_profil_temp.dart
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/features/reflexe/screens/reflexe_profil_temp.dart
+++ b/lib/features/reflexe/screens/reflexe_profil_temp.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/reflex_profile.dart';
+import '../services/reflex_profile_service.dart';
+
+/// Temporary screen showing reflex result counts.
+class ReflexeProfilTempScreen extends StatelessWidget {
+  /// Map of reflex name -> result counts.
+  final Map<String, ReflexResult> results;
+
+  const ReflexeProfilTempScreen({super.key, required this.results});
+
+  Future<void> _save(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Profil speichern?'),
+        content: const Text('Möchtest du dieses Reflexprofil speichern?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Abbrechen'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await context.read<ReflexProfileService>().saveProfile(results);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Profil gespeichert')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Reflexprofil'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: () => _save(context),
+          ),
+        ],
+      ),
+      body: ListView(
+        children: results.entries
+            .map(
+              (e) => ListTile(
+                title: Text(e.key),
+                trailing:
+                    Text('${e.value.yesCount}/${e.value.answeredCount}'),
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/features/reflexe/services/reflex_profile_service.dart
+++ b/lib/features/reflexe/services/reflex_profile_service.dart
@@ -1,3 +1,5 @@
+// lib/features/reflexe/services/reflex_profile_service.dart
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/reflex_profile.dart';

--- a/lib/features/reflexe/services/reflex_profile_service.dart
+++ b/lib/features/reflexe/services/reflex_profile_service.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/reflex_profile.dart';
+
+/// Service for persisting reflex profiles in Firestore.
+class ReflexProfileService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  /// Saves a profile for the current user.
+  Future<void> saveProfile(Map<String, ReflexResult> results) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return;
+
+    final data = {
+      'createdAt': Timestamp.now(),
+      'results': {
+        for (var entry in results.entries) entry.key: entry.value.toMap(),
+      },
+    };
+    await _firestore
+        .collection('users')
+        .doc(uid)
+        .collection('reflex_profiles')
+        .add(data);
+  }
+
+  /// Loads all stored profiles for the current user ordered by date desc.
+  Future<List<ReflexProfile>> loadProfiles() async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return [];
+    final snap = await _firestore
+        .collection('users')
+        .doc(uid)
+        .collection('reflex_profiles')
+        .orderBy('createdAt', descending: true)
+        .get();
+    return snap.docs
+        .map((d) => ReflexProfile.fromDoc(d))
+        .toList();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,9 @@ import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
+import 'package:bugbear_app/features/reflexe/services/reflex_profile_service.dart';
+import 'package:bugbear_app/features/reflexe/screens/reflexe_profil.dart';
+import 'package:bugbear_app/features/reflexe/screens/reflexe_profil_temp.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -101,6 +104,9 @@ class MyApp extends StatelessWidget {
         Provider<CalendarService>(
           create: (_) => CalendarService(),
         ),
+        Provider<ReflexProfileService>(
+          create: (_) => ReflexProfileService(),
+        ),
         Provider<ExerciseRepository>(
           create: (_) => ExerciseRepository(),
         ),
@@ -133,6 +139,7 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
+          '/reflex-profil': (c) => const ReflexeProfilScreen(),
         },
       ),
     );


### PR DESCRIPTION
## Summary
- add `ReflexProfile` model and service to store profiles in Firestore
- implement `ReflexeProfilTempScreen` for displaying counts and saving
- implement `ReflexeProfilScreen` to view saved profiles
- provide `ReflexProfileService` through `MultiProvider` and route `/reflex-profil`

## Testing
- `git status --short`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a9f3ef6c832dbdb1bb80fa5373d2