### PR TITLE
Implement questionnaire screens

### DIFF
--- a/lib/features/questionnaire/models/question_item.dart
+++ b/lib/features/questionnaire/models/question_item.dart
@@ -1,0 +1,26 @@
+
+class QuestionItem {
+  final String id;
+  final List<String> reflexKeys;
+  final List<String> reflexNames;
+  final String text;
+  final String example;
+
+  QuestionItem({
+    required this.id,
+    required this.reflexKeys,
+    required this.reflexNames,
+    required this.text,
+    required this.example,
+  });
+
+  factory QuestionItem.fromJson(Map<String, dynamic> json) {
+    return QuestionItem(
+      id: json['id'] as String,
+      reflexKeys: List<String>.from(json['reflex_keys'] as List),
+      reflexNames: List<String>.from(json['reflex_names'] as List),
+      text: (json['frage'] ?? json['question']) as String,
+      example: (json['beispiel'] ?? json['example']) as String,
+    );
+  }
+}

--- a/lib/features/questionnaire/models/questionnaire_progress.dart
+++ b/lib/features/questionnaire/models/questionnaire_progress.dart
@@ -1,0 +1,25 @@
+class QuestionnaireProgress {
+  String language;
+  int index;
+  Map<String, String> answers;
+
+  QuestionnaireProgress({
+    required this.language,
+    required this.index,
+    required this.answers,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'language': language,
+        'index': index,
+        'answers': answers,
+      };
+
+  factory QuestionnaireProgress.fromMap(Map<dynamic, dynamic> map) {
+    return QuestionnaireProgress(
+      language: (map['language'] as String?) ?? 'de',
+      index: (map['index'] as int?) ?? 0,
+      answers: Map<String, String>.from(map['answers'] as Map? ?? {}),
+    );
+  }
+}

--- a/lib/features/questionnaire/notifier/questionnaire_notifier.dart
+++ b/lib/features/questionnaire/notifier/questionnaire_notifier.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/foundation.dart';
+import '../models/question_item.dart';
+import '../models/questionnaire_progress.dart';
+import '../services/questionnaire_repository.dart';
+
+class QuestionnaireNotifier extends ChangeNotifier {
+  final QuestionnaireRepository _repo;
+  QuestionnaireProgress _progress;
+  List<QuestionItem> _questions = [];
+
+  QuestionnaireNotifier(this._repo, this._progress);
+
+  List<QuestionItem> get questions => _questions;
+  int get index => _progress.index;
+  String get language => _progress.language;
+  Map<String, String> get answers => _progress.answers;
+
+  QuestionItem? get currentQuestion =>
+      index < _questions.length ? _questions[index] : null;
+
+  Future<void> loadQuestions() async {
+    _questions = await _repo.loadQuestions(_progress.language);
+    if (_progress.index > _questions.length) {
+      _progress.index = _questions.length;
+    }
+    notifyListeners();
+  }
+
+  Future<void> start(String language) async {
+    _progress.language = language;
+    _progress.index = 0;
+    _progress.answers.clear();
+    await _repo.saveProgress(_progress);
+    await loadQuestions();
+  }
+
+  Future<void> answer(String value) async {
+    final q = currentQuestion;
+    if (q == null) return;
+    _progress.answers[q.id] = value;
+    _progress.index++;
+    await _repo.saveProgress(_progress);
+    notifyListeners();
+  }
+
+  void next() {
+    if (_progress.index < _questions.length - 1) {
+      _progress.index++;
+      _repo.saveProgress(_progress);
+      notifyListeners();
+    }
+  }
+
+  void previous() {
+    if (_progress.index > 0) {
+      _progress.index--;
+      _repo.saveProgress(_progress);
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/questionnaire/screens/questionnaire_language_screen.dart
+++ b/lib/features/questionnaire/screens/questionnaire_language_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:bugbear_app/features/questionnaire/notifier/questionnaire_notifier.dart';
+
+class QuestionnaireLanguageScreen extends StatelessWidget {
+  const QuestionnaireLanguageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final notifier = context.read<QuestionnaireNotifier>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Questionnaire Language')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () async {
+                await notifier.start('en');
+                if (context.mounted) {
+                  Navigator.pushReplacementNamed(context, '/questionnaire');
+                }
+              },
+              child: const Text('English'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                await notifier.start('de');
+                if (context.mounted) {
+                  Navigator.pushReplacementNamed(context, '/questionnaire');
+                }
+              },
+              child: const Text('Deutsch'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/questionnaire/screens/questionnaire_screen.dart
+++ b/lib/features/questionnaire/screens/questionnaire_screen.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:bugbear_app/features/questionnaire/notifier/questionnaire_notifier.dart';
+
+class QuestionnaireScreen extends StatefulWidget {
+  const QuestionnaireScreen({super.key});
+
+  @override
+  State<QuestionnaireScreen> createState() => _QuestionnaireScreenState();
+}
+
+class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
+  bool _showInfo = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final notifier = context.watch<QuestionnaireNotifier>();
+    final q = notifier.currentQuestion;
+    if (q == null) {
+      // Finished
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Navigator.pushReplacementNamed(context, '/reflexe_profil_temp');
+      });
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    final total = notifier.questions.length;
+    return Scaffold(
+      drawer: const AppDrawer(),
+      appBar: AppBar(
+        title: Text('${q.id}/$total'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            onPressed: () {
+              setState(() => _showInfo = !_showInfo);
+            },
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: notifier.index > 0 ? notifier.previous : null,
+                    ),
+                    Expanded(
+                      child: Text(
+                        q.text,
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.arrow_forward),
+                      onPressed: notifier.index < total - 1 ? notifier.next : null,
+                    ),
+                  ],
+                ),
+              ),
+              const Spacer(),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () async {
+                        await notifier.answer('Ja');
+                      },
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size(80, 60),
+                      ),
+                      child: const Text('Ja'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () async {
+                        await notifier.answer('X');
+                      },
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size(80, 60),
+                      ),
+                      child: const Text('X'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () async {
+                        await notifier.answer('Nein');
+                      },
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size(80, 60),
+                      ),
+                      child: const Text('Nein'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (_showInfo)
+            Positioned.fill(
+              child: Container(
+                color: Colors.black54,
+                child: Center(
+                  child: Material(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(q.reflexNames.join(', '),
+                              style: Theme.of(context).textTheme.titleMedium),
+                          const SizedBox(height: 8),
+                          Text(q.example),
+                          const SizedBox(height: 8),
+                          ElevatedButton(
+                            onPressed: () {
+                              setState(() => _showInfo = false);
+                            },
+                            child: const Text('OK'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/questionnaire/screens/reflexe_profil_temp.dart
+++ b/lib/features/questionnaire/screens/reflexe_profil_temp.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ReflexeProfilTemp extends StatelessWidget {
+  const ReflexeProfilTemp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reflexe Profil')),
+      body: const Center(
+        child: Text('Profil (temporär)'),
+      ),
+    );
+  }
+}

--- a/lib/features/questionnaire/services/questionnaire_repository.dart
+++ b/lib/features/questionnaire/services/questionnaire_repository.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:hive/hive.dart';
+import '../models/question_item.dart';
+import '../models/questionnaire_progress.dart';
+
+class QuestionnaireRepository {
+  static const String _boxName = 'questionnaire_state';
+  static const String _key = 'progress';
+
+  Future<List<QuestionItem>> loadQuestions(String languageCode) async {
+    final asset = languageCode == 'de'
+        ? 'assets/quiz_questions_de.json'
+        : 'assets/quiz_questions_en.json';
+    final str = await rootBundle.loadString(asset);
+    final list = json.decode(str) as List<dynamic>;
+    return list
+        .map((e) => QuestionItem.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Box> _box() async => Hive.box(_boxName);
+
+  Future<QuestionnaireProgress?> loadProgress() async {
+    final box = await _box();
+    final data = box.get(_key);
+    if (data is Map) {
+      return QuestionnaireProgress.fromMap(data as Map);
+    }
+    return null;
+  }
+
+  Future<void> saveProgress(QuestionnaireProgress progress) async {
+    final box = await _box();
+    await box.put(_key, progress.toMap());
+  }
+
+  Future<void> clear() async {
+    final box = await _box();
+    await box.delete(_key);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,12 @@ import 'package:bugbear_app/features/training/services/session_repository.dart';
 import 'package:bugbear_app/features/training/services/sync_service.dart';
 import 'package:bugbear_app/features/training/services/exercise_repository.dart';
 import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
+import 'package:bugbear_app/features/questionnaire/services/questionnaire_repository.dart';
+import 'package:bugbear_app/features/questionnaire/notifier/questionnaire_notifier.dart';
+import 'package:bugbear_app/features/questionnaire/models/questionnaire_progress.dart';
+import 'package:bugbear_app/features/questionnaire/screens/questionnaire_language_screen.dart';
+import 'package:bugbear_app/features/questionnaire/screens/questionnaire_screen.dart';
+import 'package:bugbear_app/features/questionnaire/screens/reflexe_profil_temp.dart';
 
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
@@ -46,6 +52,14 @@ Future<void> main() async {
   Hive.registerAdapter(CalendarEventAdapter());
   await Hive.openBox<CalendarEvent>('calendar_events');
 
+  // Questionnaire persistence
+  await Hive.openBox('questionnaire_state');
+
+  final questionnaireRepository = QuestionnaireRepository();
+  final savedProgress = await questionnaireRepository.loadProgress();
+  final initialProgress = savedProgress ??
+      QuestionnaireProgress(language: 'de', index: 0, answers: {});
+
 
   final sessionRepository = SessionRepository();
   final saved = await sessionRepository.load();
@@ -63,6 +77,8 @@ Future<void> main() async {
     MyApp(
       sessionRepository: sessionRepository,
       initialSessionState: initialState,
+      questionnaireRepository: questionnaireRepository,
+      initialProgress: initialProgress,
     ),
   );
 }
@@ -70,11 +86,15 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   final SessionRepository sessionRepository;
   final SessionState initialSessionState;
+  final QuestionnaireRepository questionnaireRepository;
+  final QuestionnaireProgress initialProgress;
 
   const MyApp({
     super.key,
     required this.sessionRepository,
     required this.initialSessionState,
+    required this.questionnaireRepository,
+    required this.initialProgress,
   });
 
   @override
@@ -103,6 +123,15 @@ class MyApp extends StatelessWidget {
         ),
         Provider<ExerciseRepository>(
           create: (_) => ExerciseRepository(),
+        ),
+        Provider<QuestionnaireRepository>.value(
+          value: questionnaireRepository,
+        ),
+        ChangeNotifierProvider<QuestionnaireNotifier>(
+          create: (_) => QuestionnaireNotifier(
+            questionnaireRepository,
+            initialProgress,
+          )..loadQuestions(),
         ),
         ChangeNotifierProvider<SessionNotifier>(
           create: (ctx) {
@@ -133,6 +162,9 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
+          '/questionnaire-language': (c) => const QuestionnaireLanguageScreen(),
+          '/questionnaire': (c) => const QuestionnaireScreen(),
+          '/reflexe_profil_temp': (c) => const ReflexeProfilTemp(),
         },
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,9 +54,11 @@ flutter:
   generate: true
   uses-material-design: true
 
-  assets:
-    - assets/images/
-    - assets/sounds/
+    assets:
+      - assets/images/
+      - assets/sounds/
+      - assets/quiz_questions_de.json
+      - assets/quiz_questions_en.json
 
 flutter_intl:
   enabled: true


### PR DESCRIPTION
## Summary
- add questionnaire data models and repository
- create questionnaire notifier
- implement language and question screens
- wire up questionnaire logic in main app
- include json assets in pubspec

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a9f3e93c832dbcfda68c040dceab