### PR TITLE
Add questionnaire notifier

### DIFF
--- a/lib/features/questionnaire/models/question.dart
+++ b/lib/features/questionnaire/models/question.dart
@@ -1,0 +1,39 @@
+class Question {
+  final String id;
+  final List<String> reflexKeys;
+  final List<String> reflexNames;
+  final String question;
+  final String example;
+  final List<String> sources;
+
+  Question({
+    required this.id,
+    required this.reflexKeys,
+    required this.reflexNames,
+    required this.question,
+    this.example = '',
+    this.sources = const [],
+  });
+
+  factory Question.fromJson(Map<String, dynamic> json) {
+    return Question(
+      id: json['id'] as String,
+      reflexKeys: List<String>.from(json['reflex_keys'] as List<dynamic>),
+      reflexNames: List<String>.from(json['reflex_names'] as List<dynamic>),
+      question: json['question'] as String,
+      example: json['example'] as String? ?? '',
+      sources: (json['sources'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'reflex_keys': reflexKeys,
+        'reflex_names': reflexNames,
+        'question': question,
+        'example': example,
+        'sources': sources,
+      };
+}

--- a/lib/features/questionnaire/models/questionnaire_state.dart
+++ b/lib/features/questionnaire/models/questionnaire_state.dart
@@ -1,0 +1,22 @@
+enum Answer { yes, no, skipped }
+
+class QuestionnaireState {
+  final int index;
+  final Map<String, Answer> answers;
+
+  QuestionnaireState({
+    required this.index,
+    required Map<String, Answer> answers,
+  }) : answers = Map<String, Answer>.from(answers);
+
+  factory QuestionnaireState.fromJson(Map<String, dynamic> json) {
+    final map = (json['answers'] as Map).cast<String, int>();
+    final ans = map.map((k, v) => MapEntry(k, Answer.values[v]));
+    return QuestionnaireState(index: json['index'] as int, answers: ans);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'index': index,
+        'answers': answers.map((k, v) => MapEntry(k, v.index)),
+      };
+}

--- a/lib/features/questionnaire/notifier/questionnaire_notifier.dart
+++ b/lib/features/questionnaire/notifier/questionnaire_notifier.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import '../models/question.dart';
+import '../models/questionnaire_state.dart';
+import '../services/questionnaire_repository.dart';
+
+/// QuestionnaireNotifier
+///
+/// Manages a list of questions and the user's answers. Answers are
+/// persisted via [QuestionnaireRepository]. Statistics per reflex can be
+/// computed based on stored answers.
+class QuestionnaireNotifier extends ChangeNotifier {
+  final QuestionnaireRepository _repo;
+  final List<Question> _questions;
+
+  int _currentIndex = 0;
+  final Map<String, Answer> _answers = {};
+
+  QuestionnaireNotifier(this._repo, this._questions);
+
+  /// Load saved progress if available.
+  Future<void> resume() async {
+    final saved = await _repo.load();
+    if (saved != null) {
+      _currentIndex = saved.index.clamp(0, _questions.length);
+      _answers
+        ..clear()
+        ..addAll(saved.answers);
+      notifyListeners();
+    }
+  }
+
+  /// Currently displayed question.
+  Question? get currentQuestion =>
+      _currentIndex < _questions.length ? _questions[_currentIndex] : null;
+
+  int get currentIndex => _currentIndex;
+  int get totalQuestions => _questions.length;
+  bool get isCompleted => _currentIndex >= _questions.length;
+  Map<String, Answer> get answers => Map.unmodifiable(_answers);
+
+  void answerYes() => _handleAnswer(Answer.yes);
+  void answerNo() => _handleAnswer(Answer.no);
+  void skip() => _handleAnswer(Answer.skipped);
+
+  void _handleAnswer(Answer value) {
+    if (isCompleted) return;
+    final id = _questions[_currentIndex].id;
+    _answers[id] = value;
+    _currentIndex++;
+    notifyListeners();
+    _repo.save(QuestionnaireState(index: _currentIndex, answers: _answers));
+  }
+
+  /// Compute ratio of "yes" answers per reflex key.
+  Map<String, double> reflexStatistics() {
+    final Map<String, int> yesCount = {};
+    final Map<String, int> totalCount = {};
+
+    for (final q in _questions) {
+      final ans = _answers[q.id];
+      if (ans == null || ans == Answer.skipped) continue;
+      for (final key in q.reflexKeys) {
+        totalCount[key] = (totalCount[key] ?? 0) + 1;
+        if (ans == Answer.yes) {
+          yesCount[key] = (yesCount[key] ?? 0) + 1;
+        }
+      }
+    }
+
+    final Map<String, double> result = {};
+    for (final key in totalCount.keys) {
+      final total = totalCount[key] ?? 1;
+      final yes = yesCount[key] ?? 0;
+      result[key] = yes / total;
+    }
+    return result;
+  }
+}

--- a/lib/features/questionnaire/services/questionnaire_repository.dart
+++ b/lib/features/questionnaire/services/questionnaire_repository.dart
@@ -1,0 +1,26 @@
+import 'package:hive/hive.dart';
+import '../models/questionnaire_state.dart';
+
+class QuestionnaireRepository {
+  static const String _boxName = 'questionnaire_state';
+  static const String _key = 'state';
+
+  Future<Box<Map>> _openBox() async => Hive.box<Map>(_boxName);
+
+  Future<QuestionnaireState?> load() async {
+    final box = await _openBox();
+    final json = box.get(_key);
+    if (json == null) return null;
+    return QuestionnaireState.fromJson(Map<String, dynamic>.from(json));
+  }
+
+  Future<void> save(QuestionnaireState state) async {
+    final box = await _openBox();
+    await box.put(_key, state.toJson());
+  }
+
+  Future<void> clear() async {
+    final box = await _openBox();
+    await box.delete(_key);
+  }
+}


### PR DESCRIPTION
## Summary
- implement new QuestionnaireNotifier to manage quiz answers
- add repository and state models for questionnaires

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a9f3724c832dbb2fa58acaaf0e28