### PR TITLE
Add questionnaire models and services

### DIFF
--- a/lib/features/questionnaire/models/question_item.dart
+++ b/lib/features/questionnaire/models/question_item.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'question_item.freezed.dart';
+part 'question_item.g.dart';
+
+@freezed
+class QuestionItem with _$QuestionItem {
+  const factory QuestionItem({
+    required String id,
+    required List<String> reflexKeys,
+    required List<String> reflexNames,
+    required String text,
+    required String example,
+    required List<String> sources,
+  }) = _QuestionItem;
+
+  factory QuestionItem.fromJson(Map<String, dynamic> json) =>
+      _$QuestionItemFromJson(json);
+}

--- a/lib/features/questionnaire/models/question_item_adapter.dart
+++ b/lib/features/questionnaire/models/question_item_adapter.dart
@@ -1,0 +1,37 @@
+import 'package:hive/hive.dart';
+
+import 'question_item.dart';
+
+class QuestionItemAdapter extends TypeAdapter<QuestionItem> {
+  @override
+  final int typeId = 3;
+
+  @override
+  QuestionItem read(BinaryReader reader) {
+    final id = reader.readString();
+    final reflexKeys = (reader.readList() as List).cast<String>();
+    final reflexNames = (reader.readList() as List).cast<String>();
+    final text = reader.readString();
+    final example = reader.readString();
+    final sources = (reader.readList() as List).cast<String>();
+    return QuestionItem(
+      id: id,
+      reflexKeys: reflexKeys,
+      reflexNames: reflexNames,
+      text: text,
+      example: example,
+      sources: sources,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, QuestionItem obj) {
+    writer
+      ..writeString(obj.id)
+      ..writeList(obj.reflexKeys)
+      ..writeList(obj.reflexNames)
+      ..writeString(obj.text)
+      ..writeString(obj.example)
+      ..writeList(obj.sources);
+  }
+}

--- a/lib/features/questionnaire/models/questionnaire_state.dart
+++ b/lib/features/questionnaire/models/questionnaire_state.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'questionnaire_state.freezed.dart';
+part 'questionnaire_state.g.dart';
+
+enum QuestionnaireLanguage { de, en }
+
+enum AnswerType { yes, partly, no }
+
+@freezed
+class QuestionnaireState with _$QuestionnaireState {
+  const factory QuestionnaireState({
+    @Default(0) int currentIndex,
+    @Default(<String, AnswerType>{}) Map<String, AnswerType> answers,
+    @Default(QuestionnaireLanguage.en) QuestionnaireLanguage language,
+  }) = _QuestionnaireState;
+
+  factory QuestionnaireState.fromJson(Map<String, dynamic> json) =>
+      _$QuestionnaireStateFromJson(json);
+}

--- a/lib/features/questionnaire/models/questionnaire_state_adapter.dart
+++ b/lib/features/questionnaire/models/questionnaire_state_adapter.dart
@@ -1,0 +1,71 @@
+import 'package:hive/hive.dart';
+
+import 'questionnaire_state.dart';
+
+class AnswerTypeAdapter extends TypeAdapter<AnswerType> {
+  @override
+  final int typeId = 4;
+
+  @override
+  AnswerType read(BinaryReader reader) {
+    final index = reader.readInt();
+    return AnswerType.values[index];
+  }
+
+  @override
+  void write(BinaryWriter writer, AnswerType obj) {
+    writer.writeInt(obj.index);
+  }
+}
+
+class QuestionnaireLanguageAdapter extends TypeAdapter<QuestionnaireLanguage> {
+  @override
+  final int typeId = 5;
+
+  @override
+  QuestionnaireLanguage read(BinaryReader reader) {
+    final index = reader.readInt();
+    return QuestionnaireLanguage.values[index];
+  }
+
+  @override
+  void write(BinaryWriter writer, QuestionnaireLanguage obj) {
+    writer.writeInt(obj.index);
+  }
+}
+
+class QuestionnaireStateAdapter extends TypeAdapter<QuestionnaireState> {
+  @override
+  final int typeId = 6;
+
+  @override
+  QuestionnaireState read(BinaryReader reader) {
+    final currentIndex = reader.readInt();
+    final answerCount = reader.readInt();
+    final answers = <String, AnswerType>{};
+    for (var i = 0; i < answerCount; i++) {
+      final key = reader.readString();
+      final value = AnswerType.values[reader.readInt()];
+      answers[key] = value;
+    }
+    final language = QuestionnaireLanguage.values[reader.readInt()];
+    return QuestionnaireState(
+      currentIndex: currentIndex,
+      answers: answers,
+      language: language,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, QuestionnaireState obj) {
+    writer
+      ..writeInt(obj.currentIndex)
+      ..writeInt(obj.answers.length);
+    obj.answers.forEach((key, value) {
+      writer
+        ..writeString(key)
+        ..writeInt(value.index);
+    });
+    writer.writeInt(obj.language.index);
+  }
+}

--- a/lib/features/questionnaire/services/question_loader.dart
+++ b/lib/features/questionnaire/services/question_loader.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../models/question_item.dart';
+import '../models/questionnaire_state.dart';
+
+class QuestionLoader {
+  Future<List<QuestionItem>> load(QuestionnaireLanguage language) async {
+    final path = language == QuestionnaireLanguage.en
+        ? 'assets/quiz_questions_en.json'
+        : 'assets/quiz_questions_de.json';
+    final content = await rootBundle.loadString(path);
+    final data = json.decode(content) as List<dynamic>;
+    return data
+        .whereType<Map<String, dynamic>>()
+        .where((e) => e.containsKey('id'))
+        .map((e) {
+          if (language == QuestionnaireLanguage.en) {
+            return QuestionItem.fromJson({
+              'id': e['id'],
+              'reflexKeys': List<String>.from(e['reflex_keys'] ?? []),
+              'reflexNames': List<String>.from(e['reflex_names'] ?? []),
+              'text': e['question'] as String? ?? '',
+              'example': e['example'] as String? ?? '',
+              'sources': List<String>.from(e['sources'] ?? []),
+            });
+          } else {
+            return QuestionItem.fromJson({
+              'id': e['id'],
+              'reflexKeys': List<String>.from(e['reflex_keys'] ?? []),
+              'reflexNames': List<String>.from(e['reflex_names'] ?? []),
+              'text': e['frage'] as String? ?? '',
+              'example': e['beispiel'] as String? ?? '',
+              'sources': List<String>.from(e['quellen'] ?? []),
+            });
+          }
+        })
+        .toList();
+  }
+}

--- a/lib/features/questionnaire/services/questionnaire_repository.dart
+++ b/lib/features/questionnaire/services/questionnaire_repository.dart
@@ -1,0 +1,26 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/questionnaire_state.dart';
+
+class QuestionnaireRepository {
+  static const String _boxName = 'questionnaire_state';
+  static const String _key = 'current';
+
+  Future<Box<QuestionnaireState>> _openBox() async =>
+      Hive.box<QuestionnaireState>(_boxName);
+
+  Future<QuestionnaireState?> load() async {
+    final box = await _openBox();
+    return box.get(_key);
+  }
+
+  Future<void> save(QuestionnaireState state) async {
+    final box = await _openBox();
+    await box.put(_key, state);
+  }
+
+  Future<void> clear() async {
+    final box = await _openBox();
+    await box.delete(_key);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,8 @@ flutter:
   assets:
     - assets/images/
     - assets/sounds/
+    - assets/quiz_questions_en.json
+    - assets/quiz_questions_de.json
 
 flutter_intl:
   enabled: true


### PR DESCRIPTION
## Summary
- define `QuestionItem` via Freezed
- track questionnaire progress with `QuestionnaireState`
- implement Hive adapters for questionnaire models
- load questions from localized JSON
- persist questionnaire state via a repository
- register JSON question assets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a9efa0b0832daf4e8cab9746d779