### PR TITLE
Add questionnaire feature

### DIFF
--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:hive/hive.dart';
+import 'package:bugbear_app/widgets/app_drawer.dart';
+
+import 'questionnaire_state.dart';
+import 'reflexe_profil_temp.dart';
+
+/// Hauptscreen des Fragebogens.
+class QuestionnaireScreen extends StatefulWidget {
+  const QuestionnaireScreen({super.key});
+
+  @override
+  State<QuestionnaireScreen> createState() => _QuestionnaireScreenState();
+}
+
+class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final state = context.read<QuestionnaireState>();
+    state.init();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<QuestionnaireState>();
+
+    if (state.isInitialized && state.questions.isEmpty) {
+      // Sprache wählen, wenn noch keine Fragen geladen wurden.
+      Future.microtask(() => _showLanguageDialog(context));
+    }
+
+    if (state.isCompleted) {
+      Future.microtask(() => _gotoResult(context));
+    }
+
+    final q = state.currentQuestion;
+    return Scaffold(
+      drawer: const AppDrawer(),
+      appBar: AppBar(
+        title: Text('${state.currentIndex + 1}/${state.questions.length}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            onPressed: state.toggleHelp,
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          if (q != null)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Text(
+                  q.question,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(fontSize: 18),
+                ),
+              ),
+            ),
+          Positioned.fill(
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: state.currentIndex == 0 ? null : state.previous,
+              ),
+            ),
+          ),
+          Positioned.fill(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                icon: const Icon(Icons.arrow_forward),
+                onPressed: state.currentIndex >= state.questions.length - 1
+                    ? null
+                    : state.next,
+              ),
+            ),
+          ),
+          if (state.helpVisible && q != null)
+            Positioned(
+              top: 80,
+              left: 16,
+              right: 16,
+              child: Material(
+                elevation: 4,
+                color: Theme.of(context).dialogBackgroundColor,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        q.reflexNames.join(', '),
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(q.example),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Row(
+          children: [
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  state.answerCurrent(QuestionAnswer.yes);
+                },
+                child: const Text('Ja'),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  state.answerCurrent(QuestionAnswer.skip);
+                },
+                child: const Text('X'),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  state.answerCurrent(QuestionAnswer.no);
+                },
+                child: const Text('Nein'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showLanguageDialog(BuildContext context) async {
+    final state = context.read<QuestionnaireState>();
+    final lang = await showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Sprache wählen'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, 'de'),
+            child: const Text('Deutsch'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, 'en'),
+            child: const Text('English'),
+          ),
+        ],
+      ),
+    );
+    if (lang != null) {
+      await state.setLanguage(lang);
+    }
+  }
+
+  void _gotoResult(BuildContext context) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const ReflexeProfilTemp()),
+    );
+  }
+}
+
+/// Hilfsfunktion für den Provider in main.dart.
+ChangeNotifierProvider<QuestionnaireState> createQuestionnaireProvider() {
+  final box = Hive.box('questionnaire_progress');
+  return ChangeNotifierProvider<QuestionnaireState>(
+    create: (_) => QuestionnaireState(box),
+  );
+}

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:hive/hive.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Einzelne Frage des Fragebogens.
+class Question {
+  final String id;
+  final List<String> reflexKeys;
+  final List<String> reflexNames;
+  final String question;
+  final String example;
+
+  Question({
+    required this.id,
+    required this.reflexKeys,
+    required this.reflexNames,
+    required this.question,
+    required this.example,
+  });
+
+  /// Erstellt eine Instanz je nach Sprach-Schlüsseln.
+  factory Question.fromJson(Map<String, dynamic> json) {
+    return Question(
+      id: json['id'] as String,
+      reflexKeys: List<String>.from(json['reflex_keys'] ?? <String>[]),
+      reflexNames: List<String>.from(json['reflex_names'] ?? <String>[]),
+      question: json['frage'] as String? ?? json['question'] as String? ?? '',
+      example: json['beispiel'] as String? ?? json['example'] as String? ?? '',
+    );
+  }
+}
+
+/// Mögliche Antworten auf eine Frage.
+enum QuestionAnswer { yes, skip, no }
+
+/// ChangeNotifier verwaltet Fragen, Antworten und Persistenz.
+class QuestionnaireState extends ChangeNotifier {
+  final Box _box;
+  List<Question> _questions = [];
+  int _index = 0;
+  Map<String, QuestionAnswer> _answers = {};
+  bool _helpVisible = false;
+  bool _isGerman = true;
+  bool _initialized = false;
+
+  QuestionnaireState(this._box);
+
+  bool get isInitialized => _initialized;
+  bool get helpVisible => _helpVisible;
+  int get currentIndex => _index;
+  List<Question> get questions => _questions;
+  Question? get currentQuestion =>
+      (_index >= 0 && _index < _questions.length) ? _questions[_index] : null;
+
+  /// Initialisiert State aus persistierten Daten.
+  Future<void> init() async {
+    _index = _box.get('index', defaultValue: 0) as int;
+    final rawAnswers = Map<String, int>.from(_box.get('answers') ?? {});
+    _answers = rawAnswers.map(
+      (k, v) => MapEntry(k, QuestionAnswer.values[v]),
+    );
+    final lang = _box.get('lang', defaultValue: 'de') as String;
+    await _loadQuestions(lang);
+    _initialized = true;
+    notifyListeners();
+  }
+
+  /// Sprache festlegen und Fragen laden.
+  Future<void> setLanguage(String lang) async {
+    await _loadQuestions(lang);
+    await _box.put('lang', lang);
+    notifyListeners();
+  }
+
+  Future<void> _loadQuestions(String lang) async {
+    _isGerman = lang.startsWith('de');
+    final path =
+        _isGerman ? 'assets/quiz_questions_de.json' : 'assets/quiz_questions_en.json';
+    final jsonStr = await rootBundle.loadString(path);
+    final data = jsonDecode(jsonStr) as List<dynamic>;
+    _questions = data
+        .whereType<Map<String, dynamic>>()
+        .where((m) => m['id'] != null)
+        .map(Question.fromJson)
+        .toList();
+    if (_index >= _questions.length) _index = _questions.length - 1;
+  }
+
+  void toggleHelp() {
+    _helpVisible = !_helpVisible;
+    notifyListeners();
+  }
+
+  void _hideHelp() {
+    if (_helpVisible) {
+      _helpVisible = false;
+    }
+  }
+
+  void previous() {
+    if (_index > 0) {
+      _index--;
+      _hideHelp();
+      _save();
+      notifyListeners();
+    }
+  }
+
+  void next() {
+    if (_index < _questions.length - 1) {
+      _index++;
+      _hideHelp();
+      _save();
+      notifyListeners();
+    }
+  }
+
+  void answerCurrent(QuestionAnswer answer) {
+    final q = currentQuestion;
+    if (q == null) return;
+    _answers[q.id] = answer;
+    _index++;
+    _hideHelp();
+    _save();
+    notifyListeners();
+  }
+
+  bool get isCompleted => _index >= _questions.length;
+
+  Future<void> _save() async {
+    final map = _answers.map((k, v) => MapEntry(k, v.index));
+    await _box.put('index', _index);
+    await _box.put('answers', map);
+    await _box.put('lang', _isGerman ? 'de' : 'en');
+  }
+
+  /// Berechnet für jedes Reflex-Label Anzahl Ja-Antworten und Gesamtfragen.
+  Map<String, List<int>> calculateReflexSummary() {
+    final result = <String, List<int>>{}; // [ja, gesamt]
+    for (final q in _questions) {
+      final ans = _answers[q.id];
+      for (final name in q.reflexNames) {
+        final entry = result.putIfAbsent(name, () => [0, 0]);
+        if (ans != QuestionAnswer.skip) {
+          entry[1] += 1;
+          if (ans == QuestionAnswer.yes) entry[0] += 1;
+        }
+      }
+    }
+    return result;
+  }
+
+  /// Speichert Ergebnis in Firestore und leert den lokalen Fortschritt.
+  Future<void> saveResult() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    final summary = calculateReflexSummary().map((k, v) =>
+        MapEntry(k, {'yes': v[0], 'total': v[1]}));
+    final answers = _answers.map((k, v) => MapEntry(k, v.name));
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .collection('tracking')
+        .add({
+      'timestamp': Timestamp.now(),
+      'answers': answers,
+      'summary': summary,
+    });
+    await _box.clear();
+  }
+}

--- a/lib/features/questionnaire/reflexe_profil_temp.dart
+++ b/lib/features/questionnaire/reflexe_profil_temp.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:bugbear_app/widgets/app_drawer.dart';
+
+import 'questionnaire_state.dart';
+
+/// Temporäre Ergebnisanzeige für die Reflexe nach dem Fragebogen.
+class ReflexeProfilTemp extends StatelessWidget {
+  const ReflexeProfilTemp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = context.watch<QuestionnaireState>().calculateReflexSummary();
+
+    return Scaffold(
+      drawer: const AppDrawer(),
+      appBar: AppBar(
+        title: const Text('Reflexe Profil'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: () async {
+              final confirmed = await showDialog<bool>(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text('Ergebnisse speichern?'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx, false),
+                      child: const Text('Nein'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx, true),
+                      child: const Text('Ja'),
+                    ),
+                  ],
+                ),
+              );
+              if (confirmed == true) {
+                await context.read<QuestionnaireState>().saveResult();
+                if (context.mounted) {
+                  Navigator.pushReplacementNamed(context, '/reflexe-profil');
+                }
+              } else {
+                Navigator.pop(context);
+              }
+            },
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: summary.entries.map((e) {
+          final name = e.key;
+          final yes = e.value[0];
+          final total = e.value[1];
+          return ListTile(
+            title: Text(name),
+            trailing: Text('$yes/$total'),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,8 @@ import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
+import 'package:bugbear_app/features/questionnaire/questionnaire_screen.dart';
+import 'package:bugbear_app/features/questionnaire/reflexe_profil_temp.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -39,6 +41,9 @@ Future<void> main() async {
   Hive.registerAdapter(SessionStatusAdapter());
   Hive.registerAdapter(SessionStateAdapter());
   await Hive.openBox<SessionState>('session_state');
+
+  // Fragebogen-Fortschritt
+  await Hive.openBox('questionnaire_progress');
 
   // CalendarEvent persistence
   Hive.registerAdapter(CalendarEventAdapter());
@@ -116,6 +121,7 @@ class MyApp extends StatelessWidget {
             );
           },
         ),
+        createQuestionnaireProvider(),
       ],
       child: MaterialApp(
         title: 'BugBear App',
@@ -130,6 +136,8 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
+          '/questionnaire': (c) => const QuestionnaireScreen(),
+          '/reflexe-profil-temp': (c) => const ReflexeProfilTemp(),
         },
       ),
     );


### PR DESCRIPTION
## Summary
- add `questionnaire` module with state, UI and result screen
- persist progress in Hive
- navigate to questionnaire and reflex profile screens
- open Hive box for questionnaire in `main.dart`

## Testing
- `dart` not available, so formatter skipped


------
https://chatgpt.com/codex/tasks/task_e_6855d4bf487c832d86adb9ccb28ec232