### PR TITLE
Fix lint warnings in questionnaire code

### DIFF
--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -28,11 +28,15 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
 
     if (state.isInitialized && state.questions.isEmpty) {
       // Sprache wählen, wenn noch keine Fragen geladen wurden.
-      Future.microtask(() => _showLanguageDialog(context));
+      Future.microtask(() {
+        if (mounted) _showLanguageDialog();
+      });
     }
 
     if (state.isCompleted) {
-      Future.microtask(() => _gotoResult(context));
+      Future.microtask(() {
+        if (mounted) _gotoResult();
+      });
     }
 
     final q = state.currentQuestion;
@@ -87,7 +91,7 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
               right: 16,
               child: Material(
                 elevation: 4,
-                color: Theme.of(context).dialogBackgroundColor,
+                color: Theme.of(context).dialogTheme.backgroundColor,
                 child: Padding(
                   padding: const EdgeInsets.all(16),
                   child: Column(
@@ -143,8 +147,7 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
     );
   }
 
-  Future<void> _showLanguageDialog(BuildContext context) async {
-    final state = context.read<QuestionnaireState>();
+  Future<void> _showLanguageDialog() async {
     final lang = await showDialog<String>(
       context: context,
       barrierDismissible: false,
@@ -162,12 +165,15 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
         ],
       ),
     );
+    if (!mounted) return;
     if (lang != null) {
+      final state = context.read<QuestionnaireState>();
       await state.setLanguage(lang);
     }
   }
 
-  void _gotoResult(BuildContext context) {
+  void _gotoResult() {
+    if (!mounted) return;
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(builder: (_) => const ReflexeProfilTemp()),

--- a/lib/features/questionnaire/reflexe_profil_temp.dart
+++ b/lib/features/questionnaire/reflexe_profil_temp.dart
@@ -36,11 +36,11 @@ class ReflexeProfilTemp extends StatelessWidget {
                   ],
                 ),
               );
+              if (!context.mounted) return;
               if (confirmed == true) {
                 await context.read<QuestionnaireState>().saveResult();
-                if (context.mounted) {
-                  Navigator.pushReplacementNamed(context, '/reflexe-profil');
-                }
+                if (!context.mounted) return;
+                Navigator.pushReplacementNamed(context, '/reflexe-profil');
               } else {
                 Navigator.pop(context);
               }


### PR DESCRIPTION
## Summary
- fix use_build_context_synchronously warnings in questionnaire widgets
- replace deprecated `dialogBackgroundColor`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d73ffa00832d92b2923aa01a2c11