### PR TITLE
Implement ReflexProfile model and saving

### DIFF
--- a/lib/features/profile/models/reflex_profile.dart
+++ b/lib/features/profile/models/reflex_profile.dart
@@ -1,0 +1,42 @@
+import "package:cloud_firestore/cloud_firestore.dart";
+
+class ReflexProfile {
+  final String id;
+  final String userId;
+  final String name;
+  final DateTime createdAt;
+  final bool isMainProfile;
+  final Map<String, dynamic> reflexScores;
+  final Map<String, String> answers;
+
+  ReflexProfile({
+    required this.id,
+    required this.userId,
+    required this.name,
+    required this.createdAt,
+    required this.isMainProfile,
+    required this.reflexScores,
+    required this.answers,
+  });
+
+  factory ReflexProfile.fromMap(Map<String, dynamic> data, String docId) {
+    return ReflexProfile(
+      id: docId,
+      userId: data['userId'] as String,
+      name: data['name'] as String? ?? '',
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      isMainProfile: data['isMainProfile'] as bool? ?? false,
+      reflexScores: Map<String, dynamic>.from(data['reflexScores'] ?? {}),
+      answers: Map<String, String>.from(data['answers'] ?? {}),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'userId': userId,
+        'name': name,
+        'createdAt': Timestamp.fromDate(createdAt),
+        'isMainProfile': isMainProfile,
+        'reflexScores': reflexScores,
+        'answers': answers,
+      };
+}

--- a/lib/features/profile/services/profile_service.dart
+++ b/lib/features/profile/services/profile_service.dart
@@ -1,0 +1,21 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/reflex_profile.dart';
+
+class ProfileService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  Future<void> saveProfile(ReflexProfile profile) {
+    return _db
+        .collection('users')
+        .doc(profile.userId)
+        .collection('profiles')
+        .doc(profile.id)
+        .set(profile.toMap());
+  }
+
+  Future<void> setMainProfile(String userId, String? profileId) {
+    final data =
+        profileId == null ? {'mainProfileId': FieldValue.delete()} : {'mainProfileId': profileId};
+    return _db.collection('users').doc(userId).set(data, SetOptions(merge: true));
+  }
+}

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:hive/hive.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:bugbear_app/features/profile/models/reflex_profile.dart';
+import 'package:bugbear_app/features/profile/services/profile_service.dart';
 
 /// Einzelne Frage des Fragebogens.
 class Question {
@@ -158,18 +160,28 @@ class QuestionnaireState extends ChangeNotifier {
   Future<void> saveResult() async {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return;
-    final summary = calculateReflexSummary().map((k, v) =>
-        MapEntry(k, {'yes': v[0], 'total': v[1]}));
+
+    final summary = calculateReflexSummary()
+        .map((k, v) => MapEntry(k, {'yes': v[0], 'total': v[1]}));
     final answers = _answers.map((k, v) => MapEntry(k, v.name));
-    await FirebaseFirestore.instance
+
+    final docRef = FirebaseFirestore.instance
         .collection('users')
         .doc(uid)
-        .collection('tracking')
-        .add({
-      'timestamp': Timestamp.now(),
-      'answers': answers,
-      'summary': summary,
-    });
+        .collection('profiles')
+        .doc();
+
+    final profile = ReflexProfile(
+      id: docRef.id,
+      userId: uid,
+      name: 'Reflexprofil',
+      createdAt: DateTime.now(),
+      isMainProfile: false,
+      reflexScores: summary,
+      answers: answers,
+    );
+
+    await ProfileService().saveProfile(profile);
     await _box.clear();
   }
 }


### PR DESCRIPTION
## Summary
- add `ReflexProfile` model in new profile feature
- provide `ProfileService` to save profiles and update a user's main profile
- update questionnaire result saving to create and store a `ReflexProfile`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68599b97ab28832dbb67c914f5026540