### PR TITLE
Add quiz intro screen

### DIFF
--- a/lib/features/questionnaire/quiz_intro_screen.dart
+++ b/lib/features/questionnaire/quiz_intro_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:bugbear_app/widgets/app_drawer.dart';
+
+/// Einf\u00fchrungsseite f\u00fcr den Fragebogen mit DSGVO-Hinweis.
+class QuizIntroScreen extends StatelessWidget {
+  const QuizIntroScreen({super.key});
+
+  Future<void> _startQuiz(BuildContext context) async {
+    final box = Hive.box('questionnaire_progress');
+    bool continueQuiz = true;
+    if (box.isNotEmpty) {
+      final result = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Fragebogen fortsetzen?'),
+          content: const Text(
+            'Es wurde ein unvollst\u00e4ndiger Fragebogen gefunden. M\u00f6chtest du fortsetzen oder neu starten?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Neu starten'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Fortsetzen'),
+            ),
+          ],
+        ),
+      );
+      if (!context.mounted) return;
+      continueQuiz = result ?? false;
+      if (!continueQuiz) await box.clear();
+    }
+
+    if (!context.mounted) return;
+    Navigator.pushReplacementNamed(context, '/questionnaire/questions');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      drawer: const AppDrawer(),
+      appBar: AppBar(title: const Text('Fragebogen')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'Mit Start des Quiz stimmst du der Verarbeitung deiner Daten gem\u00e4\u00df DSGVO zu.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => _startQuiz(context),
+              child: const Text('Quiz starten'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
 import 'package:bugbear_app/features/questionnaire/questionnaire_screen.dart';
+import 'package:bugbear_app/features/questionnaire/quiz_intro_screen.dart';
 import 'package:bugbear_app/features/questionnaire/reflexe_profil_temp.dart';
 
 Future<void> main() async {
@@ -136,7 +137,8 @@ class MyApp extends StatelessWidget {
           '/settings': (c) => const SettingsScreen(),
           '/training': (c) => const TrainingScreen(),
           '/calendar': (c) => const CalendarScreen(),
-          '/questionnaire': (c) => const QuestionnaireScreen(),
+          '/questionnaire': (c) => const QuizIntroScreen(),
+          '/questionnaire/questions': (c) => const QuestionnaireScreen(),
           '/reflexe-profil-temp': (c) => const ReflexeProfilTemp(),
         },
       ),


### PR DESCRIPTION
## Summary
- add `QuizIntroScreen` to show DSGVO info and resume option
- register intro screen in routes before the questionnaire

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599d42bd1c832d95a0c05e550233bf