### PR TITLE
Improve questionnaire UX

### DIFF
--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -48,6 +48,12 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen>
       });
     }
 
+    if (state.skipWarningNeeded) {
+      Future.microtask(() {
+        if (mounted) _showSkipWarning(state);
+      });
+    }
+
     final q = state.currentQuestion;
 
     return DefaultTabController(
@@ -85,19 +91,39 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen>
   }
 
   Widget _buildQuestionTab(Question? q, QuestionnaireState state) {
+    final progress = state.questions.isEmpty
+        ? 0.0
+        : (state.currentIndex.clamp(0, state.questions.length) /
+            state.questions.length);
+    final questionLabel =
+        'Frage ${state.currentIndex.clamp(0, state.questions.length) + 1} von ${state.questions.length}';
+
     return Stack(
       children: [
-        if (q != null)
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24.0),
-              child: Text(
-                q.question,
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 18),
-              ),
+        Column(
+          children: [
+            const SizedBox(height: 16),
+            Text(questionLabel),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 8),
+              child: LinearProgressIndicator(value: progress),
             ),
-          ),
+            const SizedBox(height: 24),
+            if (q != null)
+              Expanded(
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                    child: Text(
+                      q.question,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 18),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
         Positioned.fill(
           child: Align(
             alignment: Alignment.centerLeft,
@@ -181,6 +207,26 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen>
         ],
       ),
     );
+  }
+
+  Future<void> _showSkipWarning(QuestionnaireState state) async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Zu viele Fragen übersprungen'),
+        content: const Text(
+            'Du hast bereits mehr als 20% der Fragen übersprungen. '
+            'Das Ergebnis könnte dadurch ungenau werden.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    state.markSkipWarningShown();
   }
 
   Future<void> _showLanguageDialog() async {

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -46,6 +46,7 @@ class QuestionnaireState extends ChangeNotifier {
   int _index = 0;
   Map<String, QuestionAnswer> _answers = {};
   bool _helpVisible = false;
+  bool _skipWarningShown = false;
   bool _isGerman = true;
   bool _initialized = false;
 
@@ -57,6 +58,19 @@ class QuestionnaireState extends ChangeNotifier {
   List<Question> get questions => _questions;
   Question? get currentQuestion =>
       (_index >= 0 && _index < _questions.length) ? _questions[_index] : null;
+
+  double get skipRatio {
+    if (_questions.isEmpty) return 0;
+    final skipped =
+        _answers.values.where((a) => a == QuestionAnswer.skip).length;
+    return skipped / _questions.length;
+  }
+
+  bool get skipWarningNeeded => !_skipWarningShown && skipRatio > 0.2;
+
+  void markSkipWarningShown() {
+    _skipWarningShown = true;
+  }
 
   /// Initialisiert State aus persistierten Daten.
   Future<void> init() async {
@@ -126,6 +140,7 @@ class QuestionnaireState extends ChangeNotifier {
     if (q == null) return;
     _answers[q.id] = answer;
     _index++;
+    if (_index > _questions.length) _index = _questions.length;
     _hideHelp();
     _save();
     notifyListeners();


### PR DESCRIPTION
## Summary
- show progress text and progress bar for questionnaire
- warn when user skips too many questions
- clamp final question index to avoid navigating past the end

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599e3beef4832da6590771e87f0a1e