### PR TITLE
Fix mounted check in questionnaire result screen

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -37,7 +37,7 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
     await context
         .read<QuestionnaireState>()
         .saveResult(name: name, isMainProfile: _isMainProfile);
-    if (!mounted) return;
+    if (!context.mounted) return;
     Navigator.pushReplacementNamed(context, '/reflexe-profil');
   }
 


### PR DESCRIPTION
## Summary
- use `context.mounted` before navigating away after saving questionnaire results

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed lib/features/questionnaire/questionnaire_result_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a1289cb4832d80c4c3b5e93a41db