### PR TITLE
Add profile overview screen

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:intl/intl.dart';
+
+import 'package:bugbear_app/widgets/app_drawer.dart';
+import '../models/reflex_profile.dart';
+import '../services/profile_service.dart';
+
+class ProfileOverviewScreen extends StatelessWidget {
+  const ProfileOverviewScreen({super.key});
+
+  Future<void> _deleteProfile(BuildContext context, String userId, String profileId, bool isMain) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Profil löschen?'),
+        content: const Text('Möchtest du dieses Profil unwiderruflich löschen?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Abbrechen')),
+          TextButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Löschen')),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      final service = ProfileService();
+      await service.deleteProfile(userId, profileId);
+      if (isMain) {
+        await service.setMainProfile(userId, null);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      return const Scaffold(body: Center(child: Text('Nicht angemeldet')));
+    }
+    final service = ProfileService();
+    return StreamBuilder<String?>(
+      stream: service.watchMainProfileId(uid),
+      builder: (context, mainSnap) {
+        final mainId = mainSnap.data;
+        return StreamBuilder<List<ReflexProfile>>(
+          stream: service.watchProfiles(uid),
+          builder: (context, snap) {
+            if (!snap.hasData) {
+              return const Scaffold(body: Center(child: CircularProgressIndicator()));
+            }
+            final profiles = snap.data!;
+            return Scaffold(
+              drawer: const AppDrawer(),
+              appBar: AppBar(title: const Text('Reflexprofile')),
+              body: Column(
+                children: [
+                  Expanded(
+                    child: profiles.isEmpty
+                        ? const Center(child: Text('Keine Profile vorhanden'))
+                        : ListView.builder(
+                            itemCount: profiles.length,
+                            itemBuilder: (ctx, i) {
+                              final p = profiles[i];
+                              final isMain = p.id == mainId;
+                              return ListTile(
+                                leading: isMain
+                                    ? const Icon(Icons.star, color: Colors.orange)
+                                    : const Icon(Icons.person),
+                                title: Text(p.name),
+                                subtitle: Text(DateFormat('dd.MM.yyyy').format(p.createdAt)),
+                                tileColor: isMain ? Colors.orange.withOpacity(0.2) : null,
+                                trailing: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    if (!isMain)
+                                      IconButton(
+                                        icon: const Icon(Icons.star_border),
+                                        onPressed: () => service.setMainProfile(uid, p.id),
+                                      ),
+                                    IconButton(
+                                      icon: const Icon(Icons.delete),
+                                      onPressed: () => _deleteProfile(context, uid, p.id, isMain),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.pushNamed(context, '/questionnaire'),
+                      child: const Text('Neues Quiz starten'),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/profile/services/profile_service.dart
+++ b/lib/features/profile/services/profile_service.dart
@@ -18,4 +18,35 @@ class ProfileService {
         profileId == null ? {'mainProfileId': FieldValue.delete()} : {'mainProfileId': profileId};
     return _db.collection('users').doc(userId).set(data, SetOptions(merge: true));
   }
+
+  /// Streamt alle Profile eines Nutzers sortiert nach Erstellungsdatum.
+  Stream<List<ReflexProfile>> watchProfiles(String userId) {
+    return _db
+        .collection('users')
+        .doc(userId)
+        .collection('profiles')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((qs) =>
+            qs.docs.map((d) => ReflexProfile.fromMap(d.data(), d.id)).toList());
+  }
+
+  /// Liefert den aktuellen Hauptprofil-ID-Stream für einen Nutzer.
+  Stream<String?> watchMainProfileId(String userId) {
+    return _db
+        .collection('users')
+        .doc(userId)
+        .snapshots()
+        .map((doc) => doc.data()?['mainProfileId'] as String?);
+  }
+
+  /// Entfernt ein Profil endgültig.
+  Future<void> deleteProfile(String userId, String profileId) {
+    return _db
+        .collection('users')
+        .doc(userId)
+        .collection('profiles')
+        .doc(profileId)
+        .delete();
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,7 @@ import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
 import 'package:bugbear_app/features/questionnaire/questionnaire_screen.dart';
 import 'package:bugbear_app/features/questionnaire/quiz_intro_screen.dart';
-import 'package:bugbear_app/features/questionnaire/questionnaire_result_screen.dart';
+import 'package:bugbear_app/features/profile/screens/profile_overview_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -139,7 +139,7 @@ class MyApp extends StatelessWidget {
           '/calendar': (c) => const CalendarScreen(),
           '/questionnaire': (c) => const QuizIntroScreen(),
           '/questionnaire/questions': (c) => const QuestionnaireScreen(),
-          '/reflexe-profil': (c) => const QuestionnaireResultScreen(),
+          '/reflexe-profil': (c) => const ProfileOverviewScreen(),
         },
       ),
     );

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -59,6 +59,14 @@ class AppDrawer extends StatelessWidget {
               },
             ),
             ListTile(
+              leading: const Icon(Icons.person),
+              title: const Text('Reflexprofile'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, '/reflexe-profil');
+              },
+            ),
+            ListTile(
               leading: const Icon(Icons.playlist_play),
               title: const Text('Phase ausw\u00e4hlen'),
               onTap: () {


### PR DESCRIPTION
## Summary
- create `ProfileOverviewScreen` to manage reflex profiles
- extend `ProfileService` with helpers for listing, watching, deleting profiles
- wire profile overview into routing and drawer menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859a2cadef0832dace215bcaf8a57fa