### PR TITLE
Fix color opacity method

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -67,7 +67,10 @@ class ProfileOverviewScreen extends StatelessWidget {
                                     : const Icon(Icons.person),
                                 title: Text(p.name),
                                 subtitle: Text(DateFormat('dd.MM.yyyy').format(p.createdAt)),
-                                tileColor: isMain ? Colors.orange.withOpacity(0.2) : null,
+                                tileColor: isMain
+                                    ? Colors.orange
+                                        .withValues(alpha: (0.2 * 255).round())
+                                    : null,
                                 trailing: Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: [


### PR DESCRIPTION
## Summary
- replace deprecated `withOpacity` call with `withValues`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a50a9ee8832d90b47cd1dbbbacec