### PR TITLE
Fix profile screen imports and color usage

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -1,7 +1,4 @@
 import 'package:flutter/material.dart';
-
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 
@@ -71,11 +68,9 @@ class ProfileOverviewScreen extends StatelessWidget {
                                 title: Text(p.name),
                                 subtitle: Text(DateFormat('dd.MM.yyyy').format(p.createdAt)),
 
-                                tileColor: isMain ? Colors.orange.withOpacity(0.2) : null,
-
                                 tileColor: isMain
                                     ? Colors.orange
-                                        .withValues(alpha: (0.2 * 255).round())
+                                        .withValues(alpha: 0.2 * 255)
                                     : null,
 
                                 trailing: Row(


### PR DESCRIPTION
## Summary
- tidy up imports in profile overview screen
- use `withValues` for tile color

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b03a2320832dab828bf663005159