### PR TITLE
Fix questionnaire screen layout and result tab

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'package:bugbear_app/widgets/app_drawer.dart';
-
 import 'questionnaire_state.dart';
 
 /// Displays questionnaire results with percentages per reflex and allows
@@ -45,14 +43,9 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
   Widget build(BuildContext context) {
     final summary = context.watch<QuestionnaireState>().calculateReflexSummary();
 
-    return Scaffold(
-      drawer: const AppDrawer(),
-      appBar: AppBar(
-        title: const Text('Reflexe Profil'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
           children: [
             Expanded(
               child: ListView(
@@ -99,7 +92,6 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
             ),
           ],
         ),
-      ),
     );
   }
 }

--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -17,16 +17,20 @@ class QuestionnaireScreen extends StatefulWidget {
 class _QuestionnaireScreenState extends State<QuestionnaireScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
+  late final VoidCallback _tabListener;
   @override
   void initState() {
     super.initState();
     final state = context.read<QuestionnaireState>();
     state.init();
     _tabController = TabController(length: 2, vsync: this);
+    _tabListener = () => setState(() {});
+    _tabController.addListener(_tabListener);
   }
 
   @override
   void dispose() {
+    _tabController.removeListener(_tabListener);
     _tabController.dispose();
     super.dispose();
   }
@@ -56,9 +60,7 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen>
 
     final q = state.currentQuestion;
 
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
+    return Scaffold(
         drawer: const AppDrawer(),
         appBar: AppBar(
           bottom: TabBar(
@@ -174,37 +176,39 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen>
   }
 
   Widget _buildAnswerButtons(QuestionnaireState state) {
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Row(
-        children: [
-          Expanded(
-            child: ElevatedButton(
-              onPressed: () {
-                state.answerCurrent(QuestionAnswer.yes);
-              },
-              child: const Text('Ja'),
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        child: Row(
+          children: [
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  state.answerCurrent(QuestionAnswer.yes);
+                },
+                child: const Text('Ja'),
+              ),
             ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: ElevatedButton(
-              onPressed: () {
-                state.answerCurrent(QuestionAnswer.skip);
-              },
-              child: const Text('X'),
+            const SizedBox(width: 8),
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  state.answerCurrent(QuestionAnswer.skip);
+                },
+                child: const Text('X'),
+              ),
             ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: ElevatedButton(
-              onPressed: () {
-                state.answerCurrent(QuestionAnswer.no);
-              },
-              child: const Text('Nein'),
+            const SizedBox(width: 8),
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {
+                  state.answerCurrent(QuestionAnswer.no);
+                },
+                child: const Text('Nein'),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- rebuild UI when questionnaire tab changes
- keep only one drawer and remove nested Scaffold from result screen
- ensure answer buttons sit above Android navigation bar

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b3b9dd5c832db3db7c89db76a845