### PR TITLE
Simplify tab controller listener

### DIFF
--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -17,20 +17,17 @@ class QuestionnaireScreen extends StatefulWidget {
 class _QuestionnaireScreenState extends State<QuestionnaireScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
-  late final VoidCallback _tabListener;
   @override
   void initState() {
     super.initState();
     final state = context.read<QuestionnaireState>();
     state.init();
     _tabController = TabController(length: 2, vsync: this);
-    _tabListener = () => setState(() {});
-    _tabController.addListener(_tabListener);
+    _tabController.addListener(() => setState(() {}));
   }
 
   @override
   void dispose() {
-    _tabController.removeListener(_tabListener);
     _tabController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- remove `_tabListener` field and use anonymous listener
- drop listener removal since anonymous listeners don't need disposal

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b87c76b4832db9d6ed7580572492