### PR TITLE
Add ReflexProfile detail view

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -67,6 +67,11 @@ class ProfileOverviewScreen extends StatelessWidget {
                                     : const Icon(Icons.person),
                                 title: Text(p.name),
                                 subtitle: Text(DateFormat('dd.MM.yyyy').format(p.createdAt)),
+                                onTap: () => Navigator.pushNamed(
+                                  context,
+                                  '/reflexe-profil/detail',
+                                  arguments: p,
+                                ),
 
                                 tileColor: isMain
                                     ? Colors.orange

--- a/lib/features/profile/screens/reflex_profile_detail_screen.dart
+++ b/lib/features/profile/screens/reflex_profile_detail_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../models/reflex_profile.dart';
+
+class ReflexProfileDetailScreen extends StatelessWidget {
+  final ReflexProfile profile;
+  const ReflexProfileDetailScreen({super.key, required this.profile});
+
+  Color _colorForPercent(double p) {
+    if (p >= 0.75) return Colors.green;
+    if (p >= 0.5) return Colors.orange;
+    return Colors.red;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(profile.name)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'Reflexe',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          ...profile.reflexScores.entries.map((e) {
+            final yes = e.value['yes'] as int? ?? 0;
+            final total = e.value['total'] as int? ?? 0;
+            final ratio = total == 0 ? 0.0 : yes / total;
+            final percent = (ratio * 100).round();
+            return ListTile(
+              title: Text(e.key),
+              subtitle: Padding(
+                padding: const EdgeInsets.only(top: 4.0),
+                child: LinearProgressIndicator(
+                  value: ratio,
+                  color: _colorForPercent(ratio),
+                  backgroundColor: Colors.grey.shade300,
+                ),
+              ),
+              trailing: Text('$percent%'),
+            );
+          }),
+          const SizedBox(height: 24),
+          const Text(
+            'Antworten',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          ...profile.answers.entries.map((e) => ListTile(
+                title: Text('Frage ${e.key}'),
+                trailing: Text(e.value),
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,8 @@ import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
 import 'package:bugbear_app/features/questionnaire/questionnaire_screen.dart';
 import 'package:bugbear_app/features/questionnaire/quiz_intro_screen.dart';
 import 'package:bugbear_app/features/profile/screens/profile_overview_screen.dart';
+import 'package:bugbear_app/features/profile/screens/reflex_profile_detail_screen.dart';
+import 'package:bugbear_app/features/profile/models/reflex_profile.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -140,6 +142,10 @@ class MyApp extends StatelessWidget {
           '/questionnaire': (c) => const QuizIntroScreen(),
           '/questionnaire/questions': (c) => const QuestionnaireScreen(),
           '/reflexe-profil': (c) => const ProfileOverviewScreen(),
+          '/reflexe-profil/detail': (c) {
+            final profile = ModalRoute.of(c)!.settings.arguments as ReflexProfile;
+            return ReflexProfileDetailScreen(profile: profile);
+          },
         },
       ),
     );


### PR DESCRIPTION
## Summary
- show details of reflex profile
- link profile list tiles to detail view
- wire detail screen into app routes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bff39b8c832da9b3b51f9f22f4dc