### PR TITLE
Fix questionnaire result screen crash

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -43,9 +43,11 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
   Widget build(BuildContext context) {
     final summary = context.watch<QuestionnaireState>().calculateReflexSummary();
 
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ergebnis')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
           children: [
             Expanded(
               child: ListView(
@@ -92,6 +94,7 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
             ),
           ],
         ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure questionnaire results are shown inside a `Scaffold`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859be3ca850832d8ef64a5956c03be6