### PR TITLE
Fix questionnaire flow and result layout

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -43,33 +43,33 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
   Widget build(BuildContext context) {
     final summary = context.watch<QuestionnaireState>().calculateReflexSummary();
 
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ergebnis')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Expanded(
-              child: ListView(
-                children: summary.entries.map((e) {
-                  final name = e.key;
-                  final yes = e.value[0];
-                  final total = e.value[1];
-                  final ratio = total == 0 ? 0.0 : yes / total;
-                  final percent = (ratio * 100).round();
-                  return ListTile(
-                    title: Text(name),
-                    subtitle: Padding(
-                      padding: const EdgeInsets.only(top: 4.0),
-                      child: LinearProgressIndicator(
-                        value: ratio,
-                        color: _colorForPercent(ratio),
-                        backgroundColor: Colors.grey.shade300,
-                      ),
-                    ),
-                    trailing: Text('$percent%'),
-                  );
-                }).toList(),
-              ),
-            ),
+            ...summary.entries.map((e) {
+              final name = e.key;
+              final yes = e.value[0];
+              final total = e.value[1];
+              final ratio = total == 0 ? 0.0 : yes / total;
+              final percent = (ratio * 100).round();
+              return ListTile(
+                title: Text(name),
+                subtitle: Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: LinearProgressIndicator(
+                    value: ratio,
+                    color: _colorForPercent(ratio),
+                    backgroundColor: Colors.grey.shade300,
+                  ),
+                ),
+                trailing: Text('$percent%'),
+              );
+            }),
+            const SizedBox(height: 24),
             TextField(
               controller: _nameController,
               decoration: const InputDecoration(
@@ -85,13 +85,18 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
               },
               title: const Text('Als Hauptprofil festlegen'),
             ),
-            const SizedBox(height: 12),
-            ElevatedButton(
-              onPressed: () => _save(context),
-              child: const Text('Speichern'),
-            ),
           ],
         ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: ElevatedButton(
+            onPressed: () => _save(context),
+            child: const Text('Speichern'),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -38,7 +38,7 @@ class _QuestionnaireScreenState extends State<QuestionnaireScreen> {
       });
     }
 
-    if (state.isCompleted) {
+    if (state.isInitialized && state.isCompleted) {
       Future.microtask(() {
         if (mounted) _gotoResult();
       });


### PR DESCRIPTION
## Summary
- prevent automatic navigation to results before questions load
- revamp result screen layout and keep Save button visible

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859be3ca850832d8ef64a5956c03be6