### PR TITLE
Fix build widget structure for result screen

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -50,11 +50,6 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
-
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-
           children: [
             ...summary.entries.map((e) {
               final name = e.key;


### PR DESCRIPTION
## Summary
- remove stray `body` call in `QuestionnaireResultScreen`
- correctly nest result content inside the `Column`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c611c038832dbdc1b4d80f0ec411