### PR TITLE
Fix redundant null check

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -102,10 +102,6 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
 
               if (!context.mounted || name == null) return;
               await _save(context, name);
-
-              if (name != null) {
-                await _save(context, name);
-              }
             },
             child: const Text('Speichern'),
           ),


### PR DESCRIPTION
## Summary
- remove unreachable `name != null` condition in questionnaire result screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d84de7e4832da1b05246d7173440