### PR TITLE
Implement main profile selection logic

### DIFF
--- a/lib/features/profile/services/profile_service.dart
+++ b/lib/features/profile/services/profile_service.dart
@@ -40,6 +40,12 @@ class ProfileService {
         .map((doc) => doc.data()?['mainProfileId'] as String?);
   }
 
+  /// Retrieves the main profile id for the user once.
+  Future<String?> getMainProfileId(String userId) async {
+    final doc = await _db.collection('users').doc(userId).get();
+    return doc.data()?['mainProfileId'] as String?;
+  }
+
   /// Entfernt ein Profil endgültig.
   Future<void> deleteProfile(String userId, String profileId) {
     return _db

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -174,10 +174,20 @@ class QuestionnaireState extends ChangeNotifier {
   /// Speichert Ergebnis in Firestore und leert den lokalen Fortschritt.
   Future<void> saveResult({
     String name = 'Reflexprofil',
-    bool isMainProfile = false,
   }) async {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return;
+
+    final service = ProfileService();
+    final mainProfileId = await service.getMainProfileId(uid);
+    final profileQuery = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .collection('profiles')
+        .limit(1)
+        .get();
+    final hasProfiles = profileQuery.docs.isNotEmpty;
+    final isMainProfile = mainProfileId == null || !hasProfiles;
 
     final summary = calculateReflexSummary()
         .map((k, v) => MapEntry(k, {'yes': v[0], 'total': v[1]}));
@@ -199,7 +209,6 @@ class QuestionnaireState extends ChangeNotifier {
       answers: answers,
     );
 
-    final service = ProfileService();
     await service.saveProfile(profile);
     if (isMainProfile) {
       await service.setMainProfile(uid, profile.id);


### PR DESCRIPTION
## Summary
- add a getter to fetch a user's main profile id
- compute main profile assignment when saving questionnaire results

## Testing
- `dart format` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d957bd74832dbfb55d7d3d44778b