### PR TITLE
Handle error in profile overview

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -40,10 +40,20 @@ class ProfileOverviewScreen extends StatelessWidget {
     return StreamBuilder<String?>(
       stream: service.watchMainProfileId(uid),
       builder: (context, mainSnap) {
+        if (mainSnap.hasError) {
+          return const Scaffold(
+            body: Center(child: Text('Fehler beim Laden der Profile')),
+          );
+        }
         final mainId = mainSnap.data;
         return StreamBuilder<List<ReflexProfile>>(
           stream: service.watchProfiles(uid),
           builder: (context, snap) {
+            if (snap.hasError) {
+              return const Scaffold(
+                body: Center(child: Text('Fehler beim Laden der Profile')),
+              );
+            }
             if (!snap.hasData) {
               return const Scaffold(body: Center(child: CircularProgressIndicator()));
             }


### PR DESCRIPTION
## Summary
- show an error message when profile streams fail

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dbb63e48832db5b29478d77ee938