### PR TITLE
Fix navigation after saving questionnaire results

### DIFF
--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -51,7 +51,11 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
     final trimmed = name.trim().isEmpty ? 'Reflexprofil' : name.trim();
     await context.read<QuestionnaireState>().saveResult(name: trimmed);
     if (!context.mounted) return;
-    Navigator.pushReplacementNamed(context, '/reflexe-profil');
+    Navigator.pushNamedAndRemoveUntil(
+      context,
+      '/reflexe-profil',
+      ModalRoute.withName('/'),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- update `_save` to push to the reflex profile route and remove previous routes

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859def079d4832db87a4776ab77d886