### PR TITLE
Fix profile overview color opacity

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -84,8 +84,7 @@ class ProfileOverviewScreen extends StatelessWidget {
                                 ),
 
                                 tileColor: isMain
-                                    ? Colors.orange
-                                        .withValues(alpha: 0.2 * 255)
+                                    ? Colors.orange.withOpacity(0.2)
                                     : null,
 
                                 trailing: Row(


### PR DESCRIPTION
## Summary
- fix deprecated `.withValues` call in `ProfileOverviewScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e26e53d4832daec389462a95dbab