### PR TITLE
Fix SnackBar context check

### DIFF
--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -219,7 +219,7 @@ class QuestionnaireState extends ChangeNotifier {
     } catch (e, st) {
       debugPrint('Error saving questionnaire result: $e');
       debugPrintStack(stackTrace: st);
-      if (context != null) {
+      if (context != null && context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('Fehler beim Speichern. Bitte erneut versuchen.'),


### PR DESCRIPTION
## Summary
- guard the SnackBar call in `QuestionnaireState.saveResult` to check if `context` is mounted

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e73a8ac4832da5af4e00c0052e71