### PR TITLE
Replace withOpacity with withAlpha

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -84,7 +84,8 @@ class ProfileOverviewScreen extends StatelessWidget {
                                 ),
 
                                 tileColor: isMain
-                                    ? Colors.orange.withOpacity(0.2)
+                                    ? Colors.orange
+                                        .withAlpha((0.2 * 255).round())
                                     : null,
 
                                 trailing: Row(


### PR DESCRIPTION
## Summary
- adjust profile list tile color using `withAlpha((0.2 * 255).round())`

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859e7aa9a54832d9e2fcbb65fb8fbe0