### PR TITLE
Fix questionnaire restart state

### DIFF
--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -155,6 +155,17 @@ class QuestionnaireState extends ChangeNotifier {
     await _box.put('lang', _isGerman ? 'de' : 'en');
   }
 
+  /// Resets all questionnaire progress and internal state.
+  void resetState() {
+    _index = 0;
+    _answers.clear();
+    _helpVisible = false;
+    _skipWarningShown = false;
+    _initialized = false;
+    _questions = [];
+    notifyListeners();
+  }
+
   /// Berechnet für jedes Reflex-Label Anzahl Ja-Antworten und Gesamtfragen.
   Map<String, List<int>> calculateReflexSummary() {
     final result = <String, List<int>>{}; // [ja, gesamt]

--- a/lib/features/questionnaire/quiz_intro_screen.dart
+++ b/lib/features/questionnaire/quiz_intro_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
+import 'package:provider/provider.dart';
 import 'package:bugbear_app/widgets/app_drawer.dart';
+
+import 'questionnaire_state.dart';
 
 /// Einf\u00fchrungsseite f\u00fcr den Fragebogen mit DSGVO-Hinweis.
 class QuizIntroScreen extends StatelessWidget {
@@ -31,7 +34,12 @@ class QuizIntroScreen extends StatelessWidget {
       );
       if (!context.mounted) return;
       continueQuiz = result ?? false;
-      if (!continueQuiz) await box.clear();
+      if (!continueQuiz) {
+        await box.clear();
+        if (context.mounted) {
+          context.read<QuestionnaireState>().resetState();
+        }
+      }
     }
 
     if (!context.mounted) return;


### PR DESCRIPTION
## Summary
- reset questionnaire progress when user opts to restart
- expose `resetState` in `QuestionnaireState`

## Testing
- `dart format lib/features/questionnaire/questionnaire_state.dart lib/features/questionnaire/quiz_intro_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e9b88ea0832da1aa28d077dc8fab