### PR TITLE
Handle auth and Firestore errors separately

### DIFF
--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -41,18 +41,20 @@ class ProfileOverviewScreen extends StatelessWidget {
       stream: service.watchMainProfileId(uid),
       builder: (context, mainSnap) {
         if (mainSnap.hasError) {
-          return const Scaffold(
-            body: Center(child: Text('Fehler beim Laden der Profile')),
-          );
+          final msg = FirebaseAuth.instance.currentUser == null
+              ? 'Nicht angemeldet'
+              : mainSnap.error.toString();
+          return Scaffold(body: Center(child: Text(msg)));
         }
         final mainId = mainSnap.data;
         return StreamBuilder<List<ReflexProfile>>(
           stream: service.watchProfiles(uid),
           builder: (context, snap) {
             if (snap.hasError) {
-              return const Scaffold(
-                body: Center(child: Text('Fehler beim Laden der Profile')),
-              );
+              final msg = FirebaseAuth.instance.currentUser == null
+                  ? 'Nicht angemeldet'
+                  : snap.error.toString();
+              return Scaffold(body: Center(child: Text(msg)));
             }
             if (!snap.hasData) {
               return const Scaffold(body: Center(child: CircularProgressIndicator()));


### PR DESCRIPTION
## Summary
- differentiate auth errors from Firestore issues in `ProfileOverviewScreen`
- show the stream-provided error when a user is logged in, otherwise show "Nicht angemeldet"

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859eac1c7fc832db1f077a13fb684dc