### PR TITLE
Handle no login when saving questionnaire

### DIFF
--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -188,7 +188,16 @@ class QuestionnaireState extends ChangeNotifier {
     BuildContext? context,
   }) async {
     final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return;
+    if (uid == null) {
+      if (context != null && context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Bitte anmelden, um das Profil zu speichern.'),
+          ),
+        );
+      }
+      return;
+    }
 
     try {
       final service = ProfileService();


### PR DESCRIPTION
## Summary
- inform user if they try saving without being logged in

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859ec6dc8bc832d932d4e766e5e36f6