### PR TITLE
Fix menu header text encoding

### DIFF
--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -14,7 +14,7 @@ class AppDrawer extends StatelessWidget {
             const DrawerHeader(
               decoration: BoxDecoration(color: Colors.blueGrey),
               child: Text(
-                'Men\u00fc',
+                'Menü',
                 style: TextStyle(fontSize: 24, color: Colors.white),
               ),
             ),


### PR DESCRIPTION
## Summary
- display the menu header with the proper umlaut

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ed172304832dbe714cd38e1ec76a