### PR TITLE
Reset questionnaire state after saving

### DIFF
--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -236,6 +236,7 @@ class QuestionnaireState extends ChangeNotifier {
         await service.setMainProfile(uid, profile.id);
       }
       await _box.clear();
+      resetState();
     } catch (e, st) {
       debugPrint('Error saving questionnaire result: $e');
       debugPrintStack(stackTrace: st);


### PR DESCRIPTION
## Summary
- reset questionnaire state once results are saved

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f118211c832d8df31120ae115db8