### PR TITLE
Handle completed questionnaire progress

### DIFF
--- a/lib/features/questionnaire/quiz_intro_screen.dart
+++ b/lib/features/questionnaire/quiz_intro_screen.dart
@@ -11,6 +11,24 @@ class QuizIntroScreen extends StatelessWidget {
 
   Future<void> _startQuiz(BuildContext context) async {
     final box = Hive.box('questionnaire_progress');
+    final state = context.read<QuestionnaireState>();
+
+    // Ensure questions are loaded to determine their count
+    if (!state.isInitialized) {
+      await state.init();
+    }
+    if (!context.mounted) return;
+
+    final storedIndex = box.get('index', defaultValue: 0) as int;
+    final questionCount = state.questions.length;
+
+    if (storedIndex >= questionCount && questionCount > 0) {
+      await box.clear();
+      if (context.mounted) {
+        state.resetState();
+      }
+    }
+
     bool continueQuiz = true;
     if (box.isNotEmpty) {
       final result = await showDialog<bool>(


### PR DESCRIPTION
## Summary
- check stored progress index on quiz start
- clear saved progress and reset state when completed

## Testing
- `dart format lib/features/questionnaire/quiz_intro_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f1ba39e4832d86eed4692f80788b