### PR TITLE
Remove unused firebase_core import

### DIFF
--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -5,7 +5,6 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:hive/hive.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:bugbear_app/features/profile/models/reflex_profile.dart';
 import 'package:bugbear_app/features/profile/services/profile_service.dart';
 


### PR DESCRIPTION
## Summary
- remove unused firebase_core import from questionnaire_state.dart

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f54e72f4832db1ac97003b6ae046