### PR TITLE
Add encryption key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ Security rules for Cloud Firestore are stored in `firestore.rules`. After making
 firebase deploy
 ```
 
+## Encryption Key Lifecycle
+
+The app encrypts all Hive boxes using a secret key. The first time the
+application runs, `SecureStorageService` generates a new key using `Hive.generateSecureKey()`.
+This key is persisted with `FlutterSecureStorage` so it remains available across
+app restarts. On subsequent launches the stored key is loaded again and reused to
+decrypt the boxes. The key only changes when the app data is cleared or the
+`FlutterSecureStorage` entry is removed.
+

--- a/lib/features/onboarding/services/secure_storage_service.dart
+++ b/lib/features/onboarding/services/secure_storage_service.dart
@@ -25,15 +25,29 @@ class SecureStorageService {
     await _storage.delete(key: _keyLoggedIn);
   }
 
-  /// Returns the persisted Hive encryption key or generates a new one.
-  Future<List<int>> getEncryptionKey() async {
+  /// Persists the given Hive encryption key.
+  Future<void> writeEncryptionKey(List<int> key) async {
+    await _storage.write(
+      key: _keyEncryption,
+      value: base64UrlEncode(key),
+    );
+  }
+
+  /// Reads the stored Hive encryption key if available.
+  Future<List<int>?> readEncryptionKey() async {
     final stored = await _storage.read(key: _keyEncryption);
-    if (stored != null) {
-      return base64Url.decode(stored);
-    }
+    return stored != null ? base64Url.decode(stored) : null;
+  }
+
+  /// Returns the persisted Hive encryption key or generates a new one if absent.
+  /// The key is kept in [FlutterSecureStorage] so it can be reused on subsequent
+  /// launches of the app.
+  Future<List<int>> getEncryptionKey() async {
+    final existing = await readEncryptionKey();
+    if (existing != null) return existing;
 
     final key = Hive.generateSecureKey();
-    await _storage.write(key: _keyEncryption, value: base64UrlEncode(key));
+    await writeEncryptionKey(key);
     return key;
   }
 }


### PR DESCRIPTION
## Summary
- expose read/write helpers for encryption key in `SecureStorageService`
- generate key when absent and reuse via `FlutterSecureStorage`
- document how the key is generated and reused across launches

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1b7ae79c832d99693168d79c03a2