### PR TITLE
Clear encryption key during logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This key is persisted with `FlutterSecureStorage` so it remains available across
 app restarts. On subsequent launches the stored key is loaded again and reused to
 decrypt the boxes. The key only changes when the app data is cleared or the
 `FlutterSecureStorage` entry is removed.
+Signing out triggers `AuthService.signOut()`, which clears `SecureStorageService`
+and deletes the stored encryption key so a fresh key is generated on the next
+launch.
 
 ## Firebase API Key Restrictions
 

--- a/lib/features/onboarding/services/secure_storage_service.dart
+++ b/lib/features/onboarding/services/secure_storage_service.dart
@@ -23,6 +23,7 @@ class SecureStorageService {
   /// Entfernt den gespeicherten Login-Status (bei Logout)
   Future<void> clear() async {
     await _storage.delete(key: _keyLoggedIn);
+    await _storage.delete(key: _keyEncryption);
   }
 
   /// Persists the given Hive encryption key.


### PR DESCRIPTION
## Summary
- remove encryption key from secure storage in `SecureStorageService.clear`
- clarify encryption key deletion on sign-out in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b23bb9428832d8504e6a1ea00f2df