### PR TITLE
Fix role selection when user missing

### DIFF
--- a/lib/features/onboarding/screens/role_selection_screen.dart
+++ b/lib/features/onboarding/screens/role_selection_screen.dart
@@ -13,7 +13,14 @@ class RoleSelectionScreen extends StatefulWidget {
 
 class RoleSelectionScreenState extends State<RoleSelectionScreen> {
   Future<void> _setRoleAndContinue(String selectedRole) async {
-    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null) {
+      if (!mounted) return;
+      Navigator.pushReplacementNamed(context, '/login');
+      return;
+    }
+
+    final uid = currentUser.uid;
     await FirebaseFirestore.instance
         .collection('users')
         .doc(uid)

--- a/test/role_selection_screen_test.dart
+++ b/test/role_selection_screen_test.dart
@@ -1,0 +1,32 @@
+import 'package:bugbear_app/features/onboarding/screens/role_selection_screen.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void setupFirebaseAuthMocks() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+}
+
+void main() {
+  setupFirebaseAuthMocks();
+
+  setUpAll(() async {
+    await Firebase.initializeApp();
+  });
+
+  testWidgets('redirects to login when no user is signed in', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        routes: {
+          '/': (_) => const RoleSelectionScreen(),
+          '/login': (_) => const Placeholder(key: Key('login-page')),
+          '/dashboard': (_) => const Placeholder(),
+        },
+      ),
+    );
+
+    await tester.tap(find.text('Personal'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('login-page')), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- handle null `FirebaseAuth` user in role selection
- add widget test for the redirect
- implement `setupFirebaseAuthMocks` for analyzer

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b248a0b7c832d8c9a71f26a09dcb7