### PR TITLE
Fix Firebase setup in role selection test

### DIFF
--- a/test/role_selection_screen_test.dart
+++ b/test/role_selection_screen_test.dart
@@ -3,11 +3,7 @@ import 'package:bugbear_app/features/onboarding/screens/role_selection_screen.da
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-void setupFirebaseAuthMocks() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-}
-
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 
 void main() {
   setupFirebaseAuthMocks();


### PR DESCRIPTION
## Summary
- use `setupFirebaseAuthMocks()` from firebase_auth_mocks
- remove custom stub function

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b31fb5834832d80227cebd7da0ceb