### PR TITLE
Handle Firebase initialization errors

### DIFF
--- a/lib/features/common/error_screen.dart
+++ b/lib/features/common/error_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class ErrorScreen extends StatelessWidget {
+  final String message;
+
+  const ErrorScreen({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Fehler')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error, size: 48, color: Colors.red),
+              const SizedBox(height: 16),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:bugbear_app/features/common/dashboard_screen.dart';
 import 'package:bugbear_app/features/onboarding/profile/settings_screen.dart';
 import 'package:bugbear_app/features/training/training_screen.dart';
 import 'package:bugbear_app/features/calendar/screens/calendar_screen.dart';
+import 'package:bugbear_app/features/common/error_screen.dart';
 
 import 'package:bugbear_app/features/training/models/session_state.dart';
 import 'package:bugbear_app/features/training/models/session_state_adapter.dart';
@@ -36,9 +37,23 @@ import 'package:bugbear_app/features/profile/models/reflex_profile.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } catch (e, st) {
+    debugPrint('Error initializing Firebase: $e');
+    debugPrintStack(stackTrace: st);
+    runApp(
+      MaterialApp(
+        home: ErrorScreen(
+          message:
+              'Firebase konnte nicht initialisiert werden. Bitte Einstellungen pr\xC3\xBCfen.',
+        ),
+      ),
+    );
+    return;
+  }
 
   await Hive.initFlutter();
   final storage = SecureStorageService();


### PR DESCRIPTION
## Summary
- create a simple `ErrorScreen` widget
- show `ErrorScreen` if `Firebase.initializeApp` throws

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b40e472fc832dad2fcd15444e6916