### PR TITLE
Fix MaterialApp constructor lint warning

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,8 +45,8 @@ Future<void> main() async {
     debugPrint('Error initializing Firebase: $e');
     debugPrintStack(stackTrace: st);
     runApp(
-      MaterialApp(
-        home: ErrorScreen(
+      const MaterialApp(
+        home: const ErrorScreen(
           message:
               'Firebase konnte nicht initialisiert werden. Bitte Einstellungen pr\xC3\xBCfen.',
         ),


### PR DESCRIPTION
## Summary
- use const `MaterialApp` and `ErrorScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b41e16250832d97008be93705212e