### PR TITLE
Fix unused const

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ Future<void> main() async {
     debugPrintStack(stackTrace: st);
     runApp(
       const MaterialApp(
-        home: const ErrorScreen(
+        home: ErrorScreen(
           message:
               'Firebase konnte nicht initialisiert werden. Bitte Einstellungen pr\xC3\xBCfen.',
         ),


### PR DESCRIPTION
## Summary
- remove redundant const from ErrorScreen in `lib/main.dart`

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b43171c8c832dbd1517c27cd3dc1e