### PR TITLE
Strengthen Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,31 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /users/{userId}/{document=**} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    match /users/{userId} {
+      allow read, write: if isOwner(userId);
+
+      match /profiles/{profileId} {
+        allow read, write: if isOwner(userId);
+      }
+
+      match /sessions/{sessionId} {
+        allow read, write: if isOwner(userId);
+      }
+
+      match /{document=**} {
+        allow read, write: if false;
+      }
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
     }
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "firestore-rules-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^2.0.0",
+    "firebase-admin": "^11.5.0",
+    "jest": "^29.0.0"
+  }
+}

--- a/test/firestore.rules.test.js
+++ b/test/firestore.rules.test.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+} = require('@firebase/rules-unit-testing');
+
+let testEnv;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'bugbear-test',
+    firestore: {
+      rules: fs.readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+function getDb(uid) {
+  return testEnv.authenticatedContext(uid).firestore();
+}
+
+function getAnonDb() {
+  return testEnv.unauthenticatedContext().firestore();
+}
+
+test('user can read and write own user document', async () => {
+  const db = getDb('alice');
+  await assertSucceeds(db.collection('users').doc('alice').set({foo: 'bar'}));
+  await assertSucceeds(db.collection('users').doc('alice').get());
+});
+
+test('user cannot read other user document', async () => {
+  const db = getDb('bob');
+  await assertFails(db.collection('users').doc('alice').get());
+});
+
+test('user can manage own profile', async () => {
+  const db = getDb('alice');
+  await assertSucceeds(
+    db
+      .collection('users')
+      .doc('alice')
+      .collection('profiles')
+      .doc('p1')
+      .set({foo: 'bar'})
+  );
+  await assertSucceeds(
+    db.collection('users').doc('alice').collection('profiles').doc('p1').get()
+  );
+});
+
+test('user cannot access unknown subcollection', async () => {
+  const db = getDb('alice');
+  await assertFails(
+    db
+      .collection('users')
+      .doc('alice')
+      .collection('unknown')
+      .doc('x')
+      .get()
+  );
+});
+
+test('user cannot read from unknown top-level collection', async () => {
+  const db = getDb('alice');
+  await assertFails(db.collection('other').doc('doc').get());
+});
+
+test('unauthenticated access is denied', async () => {
+  const db = getAnonDb();
+  await assertFails(db.collection('users').doc('alice').get());
+});


### PR DESCRIPTION
## Summary
- secure Firestore rules by explicitly matching each allowed collection
- add Jest based rules tests using the Firebase emulator
- configure a Node test environment

## Testing
- `npm install --silent` *(fails: internet disabled)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b44c20f3c832dac385930d747ada0