### PR TITLE
Improve README instructions for Firebase defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,15 @@ during startup.
 These variables can also be configured in your CI environment with the same
 names when running `flutter build`.
 
+
+### Using a key file for local development
+Instead of supplying dozens of `--dart-define` options every time, the values can
+be stored in a JSON file. Create `key_values.json` with all the required keys and
+run:
+
+```bash
+flutter run --dart-define-from-file=key_values.json
+```
+
+This loads each environment variable from the JSON file so Firebase initializes
+successfully.


### PR DESCRIPTION
## Summary
- document how to load Firebase `--dart-define` variables from a JSON file

## Testing
- `npm test` *(fails: `jest` not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd902cc4832da9c88e62f0c05712