### PR TITLE
Implement Golden Day scheduling

### DIFF
--- a/lib/features/calendar/services/golden_day_service.dart
+++ b/lib/features/calendar/services/golden_day_service.dart
@@ -1,0 +1,32 @@
+// lib/features/calendar/services/golden_day_service.dart
+
+/// GoldenDayService
+///
+/// Provides logic to calculate the next golden day for a phase.
+class GoldenDayService {
+  /// Calculates the upcoming Golden Day based on the phase start [phaseStart]
+  /// and the amount of completed sessions per week [weeklyCounts].
+  ///
+  /// [weeklyCounts] should use the week index starting at `0` for the first
+  /// week. Each value represents how many training sessions were completed in
+  /// that week. Normally six sessions are expected each week. If fewer or more
+  /// sessions were done, the Golden Day is shifted later or earlier
+  /// accordingly.
+  DateTime calculateGoldenDay(
+      DateTime phaseStart, Map<int, int> weeklyCounts) {
+    // normalize phaseStart to remove any time component
+    final start = DateTime(phaseStart.year, phaseStart.month, phaseStart.day);
+
+    // number of fully completed weeks
+    final weeks = weeklyCounts.length;
+
+    // accumulated shift due to weeks with not exactly six sessions
+    var shift = 0;
+    for (final entry in weeklyCounts.entries) {
+      shift += (6 - entry.value);
+    }
+
+    return start.add(Duration(days: 6 + weeks * 7 + shift));
+  }
+}
+

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -15,12 +15,21 @@ import 'package:bugbear_app/features/training/services/sync_service.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/training/services/exercise_repository.dart';
+import 'package:bugbear_app/features/calendar/services/golden_day_service.dart';
 
 class SessionNotifier extends ChangeNotifier {
   final SessionRepository _repo;
   final SyncService _syncService;
   final CalendarService _calendarService;
+  final GoldenDayService _goldenDayService;
   final ExerciseRepository _exerciseRepo;
+
+  /// Tracks the number of completed sessions per week starting from
+  /// the beginning of the current phase.
+  final Map<int, int> _weeklyCounts = {};
+
+  /// Start date of the current phase.
+  DateTime _phaseStart;
 
   late List<ExerciseItem> _exercises;
   Timer? _timer;
@@ -31,10 +40,13 @@ class SessionNotifier extends ChangeNotifier {
     this._repo,
     this._syncService,
     this._calendarService,
+    this._goldenDayService,
     this._exerciseRepo,
     List<ExerciseItem> initialExercises,
-    this._state,
-  ) : _exercises = initialExercises;
+    SessionState state,
+  )   : _exercises = initialExercises,
+        _state = state,
+        _phaseStart = state.startedAt;
 
   SessionState get state => _state;
   List<ExerciseItem> get exercises => _exercises;
@@ -68,6 +80,7 @@ class SessionNotifier extends ChangeNotifier {
     _timer?.cancel();
     _timer = null;
     _inRest = false;
+    _weeklyCounts.clear();
     _exercises = _exerciseRepo.getExercisesForPhase(newPhaseId);
     final first = _exercises.first;
     state = SessionState(
@@ -78,6 +91,7 @@ class SessionNotifier extends ChangeNotifier {
       isPaused: true,
       startedAt: DateTime.now(),
     );
+    _phaseStart = state.startedAt;
   }
 
   void _tick(Timer timer) {
@@ -130,6 +144,24 @@ class SessionNotifier extends ChangeNotifier {
       // Kalender-Event erstellen statt undefined addSessionEvent
       final event = CalendarEvent.fromSession(state);
       _calendarService.addEvent(event);
+
+      // update weekly counts
+      final weekIndex =
+          state.startedAt.difference(_phaseStart).inDays ~/ 7;
+      _weeklyCounts.update(weekIndex, (v) => v + 1, ifAbsent: () => 1);
+
+      // calculate and persist the next Golden Day
+      final goldenDay =
+          _goldenDayService.calculateGoldenDay(_phaseStart, _weeklyCounts);
+      final gdEvent = CalendarEvent(
+        id: 'golden_${goldenDay.toIso8601String()}',
+        date: DateTime(goldenDay.year, goldenDay.month, goldenDay.day),
+        title: 'Golden Day',
+        isCompleted: false,
+        isGoldenDay: true,
+        notes: '',
+      );
+      _calendarService.addEvent(gdEvent);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
 import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
 import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
+import 'package:bugbear_app/features/calendar/services/golden_day_service.dart';
 import 'package:bugbear_app/features/questionnaire/questionnaire_screen.dart';
 import 'package:bugbear_app/features/questionnaire/quiz_intro_screen.dart';
 import 'package:bugbear_app/features/profile/screens/profile_overview_screen.dart';
@@ -136,6 +137,9 @@ class MyApp extends StatelessWidget {
         Provider<CalendarService>(
           create: (_) => CalendarService(),
         ),
+        Provider<GoldenDayService>(
+          create: (_) => GoldenDayService(),
+        ),
         Provider<ExerciseRepository>(
           create: (_) => ExerciseRepository(),
         ),
@@ -148,6 +152,7 @@ class MyApp extends StatelessWidget {
               sessionRepository,
               ctx.read<SyncService>(),
               ctx.read<CalendarService>(),
+              ctx.read<GoldenDayService>(),
               exRepo,
               initialExercises,
               initialSessionState,

--- a/test/golden_day_test.dart
+++ b/test/golden_day_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bugbear_app/features/calendar/services/golden_day_service.dart';
+
+void main() {
+  final service = GoldenDayService();
+
+  group('GoldenDayService', () {
+    test('no weeks -> first golden day after 6 days', () {
+      final start = DateTime(2024, 1, 1); // monday
+      final result = service.calculateGoldenDay(start, {});
+      expect(result, start.add(const Duration(days: 6)));
+    });
+
+    test('complete week keeps weekday', () {
+      final start = DateTime(2024, 1, 1);
+      final result = service.calculateGoldenDay(start, {0: 6});
+      expect(result, start.add(const Duration(days: 13)));
+    });
+
+    test('missing sessions shift later', () {
+      final start = DateTime(2024, 1, 1);
+      final result = service.calculateGoldenDay(start, {0: 5});
+      expect(result, start.add(const Duration(days: 14)));
+    });
+
+    test('extra sessions shift earlier', () {
+      final start = DateTime(2024, 1, 1);
+      final result = service.calculateGoldenDay(start, {0: 7});
+      expect(result, start.add(const Duration(days: 12)));
+    });
+
+    test('multiple weeks accumulate shift', () {
+      final start = DateTime(2024, 1, 1);
+      final result = service.calculateGoldenDay(start, {0: 6, 1: 4});
+      expect(result, start.add(const Duration(days: 22)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `GoldenDayService` to calculate upcoming Golden Days
- integrate service in `SessionNotifier`
- expose service from `main.dart`
- cover shifting rules via unit tests

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0d073568832db9bb84ba9a12d290