### PR TITLE
Fix grid delegate const initialization

### DIFF
--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -56,7 +56,7 @@ class LevelMapCalendar extends StatelessWidget {
                   height: 6 * cellSize,
                   child: GridView.builder(
                     physics: const NeverScrollableScrollPhysics(),
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 7,
                       childAspectRatio: 1,
                     ),


### PR DESCRIPTION
## Summary
- add `const` to `SliverGridDelegateWithFixedCrossAxisCount` in `level_map_calendar.dart`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1f872de8832d964de06f69e4d594