### PR TITLE
Fix duplicate vars in level map calendar

### DIFF
--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -81,12 +81,6 @@ class LevelMapCalendar extends StatelessWidget {
                               : completedCount / events.length;
 
 
-                      final events = eventLoader(date);
-                      final isSelected = _isSameDay(date, selectedDay);
-
-                      bool hasGolden = events.any((e) => e.isGoldenDay);
-                      bool hasCompleted = events.any((e) => e.isCompleted);
-
                       final icon = hasGolden
                           ? Icons.star
                           : hasCompleted
@@ -158,23 +152,6 @@ class LevelMapCalendar extends StatelessWidget {
                                   Icon(icon, size: cellSize / 3, color: iconColor),
                                 ],
                               ),
-
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                '${date.day}',
-                                style: TextStyle(
-                                  fontWeight:
-                                      isSelected ? FontWeight.bold : FontWeight.normal,
-                                  color: inMonth ? null : Colors.grey,
-                                ),
-                              ),
-                              const SizedBox(height: 2),
-                              Icon(icon, size: cellSize / 3, color: iconColor),
-
-                            ],
-                          ),
                         ),
                       );
                     },


### PR DESCRIPTION
## Summary
- remove duplicate declarations in LevelMapCalendar
- clean up nested widgets causing analyzer errors

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e29eb5064832db5d8b44472b4e233