### PR TITLE
Fix LevelMapCalendar unmatched bracket

### DIFF
--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -152,7 +152,8 @@ class LevelMapCalendar extends StatelessWidget {
                                   Icon(icon, size: cellSize / 3, color: iconColor),
                                 ],
                               ),
-                        ),
+                              ],
+                          ),
                       );
                     },
                   ),


### PR DESCRIPTION
## Summary
- fix unmatched bracket in `LevelMapCalendar`

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1684f3f4832dbe33187edfb34022