### PR TITLE
Fix unmatched parenthesis in LevelMapCalendar

### DIFF
--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -175,5 +175,6 @@ class LevelMapCalendar extends StatelessWidget {
         );
       },
     );
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add missing closing parenthesis for `LayoutBuilder`

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1882e2b0832da761b7d69f61d4c1