### PR TITLE
Fix closing parenthesis in calendar widget

### DIFF
--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -154,6 +154,7 @@ class LevelMapCalendar extends StatelessWidget {
                               ),
                               ],
                           ),
+                        ),
                       );
                     },
                   ),


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in `level_map_calendar.dart`

## Testing
- `dart format lib/features/calendar/widgets/level_map_calendar.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f1ecfb6e0832d8fffae14ffd02a86