### PR TITLE
Add weekday header

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -94,30 +94,28 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
     return Scaffold(
       drawer: const AppDrawer(),
       appBar: AppBar(title: const Text('Dein Trainingskalender')),
-
-      body: PageView.builder(
-        scrollDirection: Axis.vertical,
-        pageSnapping: false,
-        controller: _pageController,
-        onPageChanged: _onPageChanged,
-        itemBuilder: (context, index) {
-          final month = _monthForIndex(index);
-          final day =
-              month.year == selectedDay.year && month.month == selectedDay.month
-                  ? selectedDay
-                  : DateTime(month.year, month.month, 1);
-          return LevelMapCalendar(
-            month: month,
-            selectedDay: day,
-            eventLoader: notifier.eventsForDay,
-            onDaySelected: _onDaySelected,
-          );
-        },
-
       body: Column(
         children: [
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              children: const [
+                for (final label in ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'])
+                  Expanded(
+                    child: Center(
+                      child: Text(
+                        label,
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
           Expanded(
             child: PageView.builder(
+              scrollDirection: Axis.vertical,
+              pageSnapping: false,
               controller: _pageController,
               onPageChanged: _onPageChanged,
               itemBuilder: (context, index) {
@@ -135,9 +133,7 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
               },
             ),
           ),
-          const Divider(),
         ],
-
       ),
     );
   }

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -37,16 +37,16 @@ class LevelMapCalendar extends StatelessWidget {
     final startDate = firstOfMonth.subtract(Duration(days: startOffset));
     return LayoutBuilder(
       builder: (context, constraints) {
-        final widthBased = constraints.maxWidth / 7;
-        final heightBased = (constraints.maxHeight - 16) / 6.7;
-        final cellSize = math.min(widthBased, heightBased);
-        final bugSize = cellSize * 0.7;
+        final cellWidth = constraints.maxWidth / 7;
+        final bugSize = cellWidth * 0.7;
+        final cellHeight = (constraints.maxHeight - bugSize - 8) / 6;
+        final aspectRatio = cellWidth / cellHeight;
 
         final selectedIndex = selectedDay.difference(startDate).inDays;
         final bugRow = selectedIndex ~/ 7;
         final bugCol = selectedIndex % 7;
-        final bugLeft = bugCol * cellSize + (cellSize - bugSize) / 2;
-        final bugTop = bugRow * cellSize + (cellSize - bugSize) / 2;
+        final bugLeft = bugCol * cellWidth + (cellWidth - bugSize) / 2;
+        final bugTop = bugRow * cellHeight + (cellHeight - bugSize) / 2;
 
         return SizedBox.expand(
           child: Stack(
@@ -56,13 +56,13 @@ class LevelMapCalendar extends StatelessWidget {
                 left: 0,
                 right: 0,
                 child: SizedBox(
-                  height: 6 * cellSize,
+                  height: 6 * cellHeight,
                   child: GridView.builder(
                     physics: const NeverScrollableScrollPhysics(),
-                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 7,
-                      childAspectRatio: 1,
-                    ),
+                      childAspectRatio: aspectRatio,
+                      ),
                     itemCount: 42,
                     itemBuilder: (ctx, i) {
                       final date = startDate.add(Duration(days: i));
@@ -151,7 +151,11 @@ class LevelMapCalendar extends StatelessWidget {
                                     ),
                                   ),
                                   const SizedBox(height: 4),
-                                  Icon(icon, size: cellSize / 3, color: iconColor),
+                                  Icon(
+                                    icon,
+                                    size: math.min(cellWidth, cellHeight) / 3,
+                                    color: iconColor,
+                                  ),
                                 ],
                               ),
                               ],


### PR DESCRIPTION
## Summary
- show weekday labels at top of `CalendarScreen`

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `dart test` *(fails: dart not installed)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f31cd3ca8832da2c7dd320908656c