### PR TITLE
Fix calendar screen layout

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -99,23 +99,13 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
           Container(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Row(
-             children: [
               children: [
-
-              children: const [
-
-
                 for (final label in ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'])
                   Expanded(
                     child: Center(
                       child: Text(
                         label,
-
                         style: const TextStyle(fontWeight: FontWeight.bold),
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-
-                        style: TextStyle(fontWeight: FontWeight.bold),
-
                       ),
                     ),
                   ),
@@ -144,25 +134,6 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
             ),
           ),
         ],
-
-      body: PageView.builder(
-        scrollDirection: Axis.vertical,
-        pageSnapping: false,
-        controller: _pageController,
-        onPageChanged: _onPageChanged,
-        itemBuilder: (context, index) {
-          final month = _monthForIndex(index);
-          final day =
-              month.year == selectedDay.year && month.month == selectedDay.month
-                  ? selectedDay
-                  : DateTime(month.year, month.month, 1);
-          return LevelMapCalendar(
-            month: month,
-            selectedDay: day,
-            eventLoader: notifier.eventsForDay,
-            onDaySelected: _onDaySelected,
-          );
-        },
       ),
     );
   }

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -39,11 +39,7 @@ class LevelMapCalendar extends StatelessWidget {
       builder: (context, constraints) {
         final cellWidth = constraints.maxWidth / 7;
         final bugSize = cellWidth * 0.7;
-
         final cellHeight = constraints.maxHeight / 6;
-
-        final cellHeight = (constraints.maxHeight - bugSize - 8) / 6;
-
         final aspectRatio = cellWidth / cellHeight;
 
         final selectedIndex = selectedDay.difference(startDate).inDays;


### PR DESCRIPTION
## Summary
- restore correct calendar layout after merge glitch

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4802c6d0832dbb808cb21292409f