### PR TITLE
Fix multiple bug images in calendar

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -120,13 +120,16 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
               onPageChanged: _onPageChanged,
               itemBuilder: (context, index) {
                 final month = _monthForIndex(index);
-                final day =
-                    month.year == selectedDay.year && month.month == selectedDay.month
-                        ? selectedDay
-                        : DateTime(month.year, month.month, 1);
+                final isSelectedMonth =
+                    month.year == selectedDay.year && month.month == selectedDay.month;
+                final isTodayMonth =
+                    month.year == DateTime.now().year && month.month == DateTime.now().month;
                 return LevelMapCalendar(
                   month: month,
-                  selectedDay: day,
+                  selectedDay: selectedDay,
+                  showBug: isSelectedMonth,
+                  showSelectedHighlight: isSelectedMonth,
+                  showTodayHighlight: isTodayMonth,
                   eventLoader: notifier.eventsForDay,
                   onDaySelected: _onDaySelected,
                 );

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -15,6 +15,9 @@ class LevelMapCalendar extends StatelessWidget {
   final DateTime selectedDay;
   final List<CalendarEvent> Function(DateTime day) eventLoader;
   final ValueChanged<DateTime> onDaySelected;
+  final bool showBug;
+  final bool showSelectedHighlight;
+  final bool showTodayHighlight;
 
   const LevelMapCalendar({
     super.key,
@@ -22,6 +25,9 @@ class LevelMapCalendar extends StatelessWidget {
     required this.selectedDay,
     required this.eventLoader,
     required this.onDaySelected,
+    this.showBug = true,
+    this.showSelectedHighlight = true,
+    this.showTodayHighlight = true,
   });
 
   static const scheduledColor = Color(0xFF0055FF);
@@ -101,8 +107,16 @@ class LevelMapCalendar extends StatelessWidget {
                         child: Container(
                           margin: const EdgeInsets.all(2),
                           decoration: BoxDecoration(
-                            color: isSelected
-                                ? scheduledColor.withAlpha((0.2 * 255).round())
+                            color: showSelectedHighlight && isSelected
+                                ? scheduledColor
+                                    .withAlpha((0.2 * 255).round())
+                                : null,
+                            border: showTodayHighlight &&
+                                    _isSameDay(date, DateTime.now())
+                                ? Border.all(
+                                    color: scheduledColor,
+                                    width: 2,
+                                  )
                                 : null,
                             borderRadius: BorderRadius.circular(4),
                           ),
@@ -166,17 +180,18 @@ class LevelMapCalendar extends StatelessWidget {
                   ),
                 ),
               ),
-              AnimatedPositioned(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeOut,
-                top: bugTop,
-                left: bugLeft,
-                child: Image.asset(
-                  'assets/images/bug.png',
-                  width: bugSize,
-                  height: bugSize,
+              if (showBug)
+                AnimatedPositioned(
+                  duration: const Duration(milliseconds: 300),
+                  curve: Curves.easeOut,
+                  top: bugTop,
+                  left: bugLeft,
+                  child: Image.asset(
+                    'assets/images/bug.png',
+                    width: bugSize,
+                    height: bugSize,
+                  ),
                 ),
-              ),
             ],
           ),
         );


### PR DESCRIPTION
## Summary
- show mascot only in selected month
- highlight today only in its month

## Testing
- `npm test` *(fails: `jest` not found)*
- `flutter test` *(fails: `flutter` not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685f4cc8da10832d8c28e5fa1f3dc15c