### PR TITLE
Fix missing parameters in calendar screen

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -122,16 +122,8 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                 final month = _monthForIndex(index);
                 final isSelectedMonth =
                     month.year == selectedDay.year && month.month == selectedDay.month;
-
                 final isTodayMonth =
                     month.year == DateTime.now().year && month.month == DateTime.now().month;
-                return LevelMapCalendar(
-                  month: month,
-                  selectedDay: selectedDay,
-                  showBug: isSelectedMonth,
-                  showSelectedHighlight: isSelectedMonth,
-                  showTodayHighlight: isTodayMonth,
-
                 final day = isSelectedMonth
                     ? selectedDay
                     : DateTime(month.year, month.month, 1);
@@ -139,7 +131,8 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                   month: month,
                   selectedDay: day,
                   showBug: isSelectedMonth,
-
+                  showSelectedHighlight: isSelectedMonth,
+                  showTodayHighlight: isTodayMonth,
                   eventLoader: notifier.eventsForDay,
                   onDaySelected: _onDaySelected,
                 );


### PR DESCRIPTION
## Summary
- fix duplicate LevelMapCalendar instantiation
- ensure selected and today highlight parameters are provided correctly

## Testing
- `npm test --silent` *(fails: jest not found, requires internet)*
- `flutter analyze` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f546e875c832db9ecded09f70c6f1