### PR TITLE
Add training completion toggle with tick marker

### DIFF
--- a/lib/features/calendar/notifier/calendar_notifier.dart
+++ b/lib/features/calendar/notifier/calendar_notifier.dart
@@ -75,4 +75,19 @@ class CalendarNotifier extends ChangeNotifier {
       }
     }
   }
+
+  /// Toggles the completed status of [event] and persists the change.
+  Future<void> toggleCompleted(CalendarEvent event) async {
+    final updated = event.copyWith(isCompleted: !event.isCompleted);
+    await _service.saveTrainingDay(updated);
+    final key = DateTime(updated.date.year, updated.date.month, updated.date.day);
+    final list = _eventsByDay[key];
+    if (list != null) {
+      final idx = list.indexWhere((e) => e.id == event.id);
+      if (idx != -1) {
+        list[idx] = updated;
+      }
+    }
+    notifyListeners();
+  }
 }

--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -177,6 +177,15 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                       : Icons.radio_button_unchecked,
                   color: ev.isCompleted ? completedColor : scheduledColor,
                 ),
+                trailing: IconButton(
+                  icon: Icon(
+                    ev.isCompleted ? Icons.undo : Icons.check,
+                    color: ev.isCompleted ? scheduledColor : completedColor,
+                  ),
+                  onPressed: () {
+                    context.read<CalendarNotifier>().toggleCompleted(ev);
+                  },
+                ),
                 onTap: () async {
                   final updated = await showDialog<CalendarEvent>(
                     context: context,

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -101,18 +101,33 @@ class LevelMapCalendar extends StatelessWidget {
                               : completedCount / events.length;
 
 
-                      final icon = hasGolden
-                          ? Icons.star
-                          : hasCompleted
-                              ? Icons.check_circle
-                              : events.isNotEmpty
-                                  ? Icons.schedule
-                                  : Icons.circle_outlined;
                       final iconColor = hasGolden
                           ? Colors.amber
                           : hasCompleted
                               ? completedColor
                               : scheduledColor;
+
+                      final iconSize = math.min(cellWidth, cellHeight) / 3;
+                      final Widget iconWidget;
+                      if (hasGolden) {
+                        iconWidget = Icon(
+                          Icons.star,
+                          size: iconSize,
+                          color: iconColor,
+                        );
+                      } else if (hasCompleted) {
+                        iconWidget = Image.asset(
+                          'assets/images/tick.png',
+                          width: iconSize,
+                          height: iconSize,
+                        );
+                      } else {
+                        iconWidget = Icon(
+                          events.isNotEmpty ? Icons.schedule : Icons.circle_outlined,
+                          size: iconSize,
+                          color: iconColor,
+                        );
+                      }
 
                       return GestureDetector(
                         onTap: () => onDaySelected(date),
@@ -177,11 +192,7 @@ class LevelMapCalendar extends StatelessWidget {
                                     ),
                                   ),
                                   const SizedBox(height: 4),
-                                  Icon(
-                                    icon,
-                                    size: math.min(cellWidth, cellHeight) / 3,
-                                    color: iconColor,
-                                  ),
+                                  iconWidget,
                                 ],
                               ),
                               ],


### PR DESCRIPTION
## Summary
- allow toggling the completion state of a calendar event
- show tick.png for completed events on level map calendar
- provide quick toggle button in day popup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7dbc9be8832d949f9403ee4dcc5f