### PR TITLE
Add training completion toggle with tick marker

### DIFF
--- a/lib/features/calendar/notifier/calendar_notifier.dart
+++ b/lib/features/calendar/notifier/calendar_notifier.dart
@@ -75,4 +75,44 @@ class CalendarNotifier extends ChangeNotifier {
       }
     }
   }
+
+  /// Toggles the completed status of [event] and persists the change.
+  Future<void> toggleCompleted(CalendarEvent event) async {
+    final updated = event.copyWith(isCompleted: !event.isCompleted);
+    await _service.saveTrainingDay(updated);
+    final key = DateTime(updated.date.year, updated.date.month, updated.date.day);
+    final list = _eventsByDay[key];
+    if (list != null) {
+      final idx = list.indexWhere((e) => e.id == event.id);
+      if (idx != -1) {
+        list[idx] = updated;
+      }
+    }
+    notifyListeners();
+  }
+
+  /// Returns true if any event for [day] is marked completed.
+  bool dayIsCompleted(DateTime day) {
+    return eventsForDay(day).any((e) => e.isCompleted);
+  }
+
+  /// Toggles completion for the first event on [day] or creates one if none exist.
+  Future<void> toggleDayCompleted(DateTime day) async {
+    final key = DateTime(day.year, day.month, day.day);
+    final list = _eventsByDay[key] ?? [];
+    if (list.isEmpty) {
+      final newEvent = CalendarEvent(
+        id: 'manual_${day.toIso8601String()}',
+        date: key,
+        title: 'Training',
+        isCompleted: true,
+      );
+      await _service.addEvent(newEvent);
+      _eventsByDay.putIfAbsent(key, () => []).add(newEvent);
+      notifyListeners();
+      return;
+    }
+
+    await toggleCompleted(list.first);
+  }
 }

--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -153,10 +153,31 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
       builder: (sheetCtx) {
         final events = notifier.eventsForDay(day);
         if (events.isEmpty) {
+          final completed = notifier.dayIsCompleted(day);
           return Dialog(
-            child: SizedBox(
-              height: MediaQuery.of(sheetCtx).size.height * 0.6,
-              child: const Center(child: Text('Keine Eintr\u00E4ge an diesem Tag')),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Keine Eintr\u00E4ge an diesem Tag'),
+                  const SizedBox(height: 16),
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      notifier.toggleDayCompleted(day);
+                    },
+                    icon: Icon(
+                      completed ? Icons.undo : Icons.check,
+                      color: completed ? scheduledColor : completedColor,
+                    ),
+                    label: Text(
+                      completed
+                          ? 'Als nicht erledigt markieren'
+                          : 'Training erledigt',
+                    ),
+                  ),
+                ],
+              ),
             ),
           );
         }
@@ -176,6 +197,15 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                       ? Icons.check_circle
                       : Icons.radio_button_unchecked,
                   color: ev.isCompleted ? completedColor : scheduledColor,
+                ),
+                trailing: IconButton(
+                  icon: Icon(
+                    ev.isCompleted ? Icons.undo : Icons.check,
+                    color: ev.isCompleted ? scheduledColor : completedColor,
+                  ),
+                  onPressed: () {
+                    context.read<CalendarNotifier>().toggleCompleted(ev);
+                  },
                 ),
                 onTap: () async {
                   final updated = await showDialog<CalendarEvent>(

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -101,18 +101,33 @@ class LevelMapCalendar extends StatelessWidget {
                               : completedCount / events.length;
 
 
-                      final icon = hasGolden
-                          ? Icons.star
-                          : hasCompleted
-                              ? Icons.check_circle
-                              : events.isNotEmpty
-                                  ? Icons.schedule
-                                  : Icons.circle_outlined;
                       final iconColor = hasGolden
                           ? Colors.amber
                           : hasCompleted
                               ? completedColor
                               : scheduledColor;
+
+                      final iconSize = math.min(cellWidth, cellHeight) / 3;
+                      final Widget iconWidget;
+                      if (hasGolden) {
+                        iconWidget = Icon(
+                          Icons.star,
+                          size: iconSize,
+                          color: iconColor,
+                        );
+                      } else if (hasCompleted) {
+                        iconWidget = Image.asset(
+                          'assets/images/tick.png',
+                          width: iconSize,
+                          height: iconSize,
+                        );
+                      } else {
+                        iconWidget = Icon(
+                          events.isNotEmpty ? Icons.schedule : Icons.circle_outlined,
+                          size: iconSize,
+                          color: iconColor,
+                        );
+                      }
 
                       return GestureDetector(
                         onTap: () => onDaySelected(date),
@@ -177,11 +192,7 @@ class LevelMapCalendar extends StatelessWidget {
                                     ),
                                   ),
                                   const SizedBox(height: 4),
-                                  Icon(
-                                    icon,
-                                    size: math.min(cellWidth, cellHeight) / 3,
-                                    color: iconColor,
-                                  ),
+                                  iconWidget,
                                 ],
                               ),
                               ],


### PR DESCRIPTION
## Summary
- allow toggling the completion state of a calendar day even when no events exist
- show button in empty-day popup to mark a session done or undo it

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7dbc9be8832d949f9403ee4dcc5f