### PR TITLE
Adjust vertical month tab layout

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -2,6 +2,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
 import '../widgets/level_map_calendar.dart';
 
 import '../models/calendar_event.dart';
@@ -127,14 +129,43 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                 final day = isSelectedMonth
                     ? selectedDay
                     : DateTime(month.year, month.month, 1);
-                return LevelMapCalendar(
-                  month: month,
-                  selectedDay: day,
-                  showBug: isSelectedMonth,
-                  showSelectedHighlight: isSelectedMonth,
-                  showTodayHighlight: isTodayMonth,
-                  eventLoader: notifier.eventsForDay,
-                  onDaySelected: _onDaySelected,
+                final monthName = DateFormat.MMMM().format(month);
+                return Stack(
+                  children: [
+                    Positioned.fill(
+                      child: LevelMapCalendar(
+                        month: month,
+                        selectedDay: day,
+                        showBug: isSelectedMonth,
+                        showSelectedHighlight: isSelectedMonth,
+                        showTodayHighlight: isTodayMonth,
+                        eventLoader: notifier.eventsForDay,
+                        onDaySelected: _onDaySelected,
+                      ),
+                    ),
+                    Positioned(
+                      right: 0,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: Container(
+                          width: 48,
+                          color: Colors.blueGrey.shade50,
+                          alignment: Alignment.center,
+                          child: RotatedBox(
+                            quarterTurns: 3,
+                            child: Text(
+                              monthName,
+                              textAlign: TextAlign.center,
+                              style: GoogleFonts.comicNeue(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 );
               },
             ),


### PR DESCRIPTION
## Summary
- fine-tune month tab placement on the calendar
- keep label centered while leaving a gap between months

## Testing
- `npm test --silent` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685f813f1694832d85754d8079dc8755