### PR TITLE
Fix calendar_screen layout regression

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -145,7 +145,6 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                     ),
                     Positioned(
                       right: 0,
-
                       child: Padding(
                         padding: const EdgeInsets.symmetric(vertical: 8),
                         child: Container(
@@ -161,29 +160,6 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                                 fontSize: 20,
                                 fontWeight: FontWeight.bold,
                               ),
-
-
-                      top: 8,
-                      bottom: 8,
-
-                      top: 0,
-                      bottom: 0,
-
-                      child: Container(
-                        width: 48,
-                        color: Colors.blueGrey.shade50,
-                        alignment: Alignment.center,
-                        child: RotatedBox(
-                          quarterTurns: 3,
-                          child: Text(
-                            monthName,
-
-                            textAlign: TextAlign.center,
-
-                            style: GoogleFonts.comicNeue(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-
                             ),
                           ),
                         ),


### PR DESCRIPTION
## Summary
- clean up duplicate month label code in `CalendarScreen`

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f85e0743c832d8f1ecdf27003eb73