### PR TITLE
Add bracket around month label

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -2,9 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 import '../widgets/level_map_calendar.dart';
+import '../widgets/month_bracket.dart';
 
 import '../models/calendar_event.dart';
 import '../dialogs/edit_training_day_dialog.dart';
@@ -145,24 +145,11 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                     ),
                     Positioned(
                       right: 0,
+                      top: 0,
+                      bottom: 0,
                       child: Padding(
                         padding: const EdgeInsets.symmetric(vertical: 8),
-                        child: Container(
-                          width: 48,
-                          color: Colors.blueGrey.shade50,
-                          alignment: Alignment.center,
-                          child: RotatedBox(
-                            quarterTurns: 3,
-                            child: Text(
-                              monthName,
-                              textAlign: TextAlign.center,
-                              style: GoogleFonts.comicNeue(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
-                        ),
+                        child: MonthBracket(monthName: monthName),
                       ),
                     ),
                   ],

--- a/lib/features/calendar/widgets/month_bracket.dart
+++ b/lib/features/calendar/widgets/month_bracket.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// Displays the month name inside a bracket along the right side of the
+/// calendar view.
+class MonthBracket extends StatelessWidget {
+  final String monthName;
+  final Color color;
+  final double width;
+
+  const MonthBracket({
+    Key? key,
+    required this.monthName,
+    this.color = Colors.blueGrey,
+    this.width = 48,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _BracketPainter(color: color),
+      child: SizedBox(
+        width: width,
+        child: Center(
+          child: RotatedBox(
+            quarterTurns: 3,
+            child: Text(
+              monthName,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.comicNeue(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BracketPainter extends CustomPainter {
+  final Color color;
+  const _BracketPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 4;
+
+    // simple rectangular bracket opening to the left
+    final double hBar = size.width * 0.6;
+    final double x = size.width - hBar;
+    canvas.drawLine(Offset(size.width, 0), Offset(x, 0), paint);
+    canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    canvas.drawLine(Offset(x, size.height), Offset(size.width, size.height), paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}


### PR DESCRIPTION
## Summary
- create `MonthBracket` widget with custom painter
- show month name using `MonthBracket` on the calendar screen
- remove an unused import from `calendar_screen.dart`

## Testing
- `npm test` *(fails: jest not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685f8858d080832da1ea3b1c9758d01b