### PR TITLE
Use Golden Day for paw position

### DIFF
--- a/lib/features/calendar/notifier/calendar_notifier.dart
+++ b/lib/features/calendar/notifier/calendar_notifier.dart
@@ -32,6 +32,23 @@ class CalendarNotifier extends ChangeNotifier {
   /// Events des aktuell selektierten Tages
   List<CalendarEvent> get eventsForSelectedDay => eventsForDay(_selectedDay);
 
+  /// Returns the next golden day based on loaded events or `null` if none.
+  DateTime? get upcomingGoldenDay {
+    final goldenEvents = _eventsByDay.values
+        .expand((e) => e)
+        .where((ev) => ev.isGoldenDay)
+        .toList();
+    if (goldenEvents.isEmpty) return null;
+    goldenEvents.sort((a, b) => a.date.compareTo(b.date));
+    final now = DateTime.now();
+    for (final ev in goldenEvents) {
+      if (!ev.date.isBefore(DateTime(now.year, now.month, now.day))) {
+        return ev.date;
+      }
+    }
+    return goldenEvents.last.date;
+  }
+
   /// Lädt alle Events des Monats [month] und behält bereits
   /// geladene Monate im Speicher, damit Marker beim Scrollen
   /// nicht verloren gehen.

--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -136,6 +136,7 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                       child: LevelMapCalendar(
                         month: month,
                         selectedDay: day,
+                        bugDay: notifier.upcomingGoldenDay,
                         showBug: isSelectedMonth,
                         showSelectedHighlight: isSelectedMonth,
                         showTodayHighlight: isTodayMonth,

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -13,6 +13,8 @@ import '../models/calendar_event.dart';
 class LevelMapCalendar extends StatelessWidget {
   final DateTime month;
   final DateTime selectedDay;
+  /// Day that controls the position of the bug mascot.
+  final DateTime? bugDay;
   final List<CalendarEvent> Function(DateTime day) eventLoader;
   final ValueChanged<DateTime> onDaySelected;
   final bool showBug;
@@ -25,6 +27,7 @@ class LevelMapCalendar extends StatelessWidget {
     super.key,
     required this.month,
     required this.selectedDay,
+    this.bugDay,
     required this.eventLoader,
     required this.onDaySelected,
     this.showBug = true,
@@ -47,12 +50,13 @@ class LevelMapCalendar extends StatelessWidget {
     // start of the six week view
     DateTime startDate = firstOfMonth.subtract(Duration(days: startOffset));
 
-    // Shift startDate so that the selected day appears on the
+    // Shift startDate so that the bug day appears on the
     // second row from the bottom (row index 4 in a 6 row grid).
-    final selectedIndex = selectedDay.difference(startDate).inDays;
-    final selectedRow = selectedIndex ~/ 7;
+    final anchorDay = bugDay ?? selectedDay;
+    final anchorIndex = anchorDay.difference(startDate).inDays;
+    final anchorRow = anchorIndex ~/ 7;
     const desiredRow = 4;
-    startDate = startDate.add(Duration(days: (selectedRow - desiredRow) * 7));
+    startDate = startDate.add(Duration(days: (anchorRow - desiredRow) * 7));
     return LayoutBuilder(
       builder: (context, constraints) {
         final cellWidth = constraints.maxWidth / 7;
@@ -61,8 +65,9 @@ class LevelMapCalendar extends StatelessWidget {
         final aspectRatio = cellWidth / cellHeight;
 
         final selectedIndex = selectedDay.difference(startDate).inDays;
-        final bugRow = selectedIndex ~/ 7;
-        final bugCol = selectedIndex % 7;
+        final bugIndex = anchorDay.difference(startDate).inDays;
+        final bugRow = bugIndex ~/ 7;
+        final bugCol = bugIndex % 7;
         final bugLeft = bugCol * cellWidth + (cellWidth - bugSize) / 2;
         final bugTop = bugRow * cellHeight + (cellHeight - bugSize) / 2;
 


### PR DESCRIPTION
## Summary
- anchor the calendar paw to the upcoming Golden Day instead of the selected day
- expose upcoming Golden Day in `CalendarNotifier`

## Testing
- `flutter test` *(fails: command not found)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8c0e48e4832da261bda16213d53c