### PR TITLE
Fix unused variable in LevelMapCalendar

### DIFF
--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -64,7 +64,6 @@ class LevelMapCalendar extends StatelessWidget {
         final cellHeight = constraints.maxHeight / 6;
         final aspectRatio = cellWidth / cellHeight;
 
-        final selectedIndex = selectedDay.difference(startDate).inDays;
         final bugIndex = anchorDay.difference(startDate).inDays;
         final bugRow = bugIndex ~/ 7;
         final bugCol = bugIndex % 7;


### PR DESCRIPTION
## Summary
- clean up LevelMapCalendar by removing an unused variable

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8dbc8ae4832d906804eaaf72dfb3