### PR TITLE
Display Golden Day on profile

### DIFF
--- a/lib/features/calendar/services/calendar_service.dart
+++ b/lib/features/calendar/services/calendar_service.dart
@@ -35,4 +35,19 @@ class CalendarService {
   Future<void> saveTrainingDay(CalendarEvent event) async {
     await _calendarBox.put(event.id, event);
   }
+
+  /// Returns the next golden day on or after today, or `null` if none exist.
+  Future<DateTime?> loadUpcomingGoldenDay() async {
+    final goldenEvents = _calendarBox.values
+        .where((e) => e.isGoldenDay)
+        .toList();
+    if (goldenEvents.isEmpty) return null;
+    goldenEvents.sort((a, b) => a.date.compareTo(b.date));
+    final today = DateTime.now();
+    final dayStart = DateTime(today.year, today.month, today.day);
+    for (final ev in goldenEvents) {
+      if (!ev.date.isBefore(dayStart)) return ev.date;
+    }
+    return goldenEvents.last.date;
+  }
 }

--- a/lib/features/profile/screens/reflex_profile_detail_screen.dart
+++ b/lib/features/profile/screens/reflex_profile_detail_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../models/reflex_profile.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../../calendar/services/calendar_service.dart';
 
 class ReflexProfileDetailScreen extends StatelessWidget {
   final ReflexProfile profile;
@@ -41,6 +44,23 @@ class ReflexProfileDetailScreen extends StatelessWidget {
               trailing: Text('$percent%'),
             );
           }),
+          const SizedBox(height: 24),
+          FutureBuilder<DateTime?>(
+            future: context.read<CalendarService>().loadUpcomingGoldenDay(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final day = snapshot.data;
+              final text = day == null
+                  ? 'Kein Golden Day geplant'
+                  : DateFormat('dd.MM.yyyy').format(day);
+              return ListTile(
+                title: const Text('Nächster Golden Day'),
+                trailing: Text(text),
+              );
+            },
+          ),
           const SizedBox(height: 24),
           const Text(
             'Antworten',


### PR DESCRIPTION
## Summary
- track upcoming Golden Day via `CalendarService.loadUpcomingGoldenDay`
- show next Golden Day in the reflex profile detail screen

## Testing
- `dart test` *(fails: `dart: command not found`)*
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f917313e8832dae448b4889fc94af