### PR TITLE
Add Golden Day banner widget

### DIFF
--- a/lib/features/calendar/widgets/golden_day_banner.dart
+++ b/lib/features/calendar/widgets/golden_day_banner.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+
+import '../services/calendar_service.dart';
+
+/// GoldenDayBanner
+///
+/// Displays the upcoming Golden Day using a paw icon and the
+/// date retrieved from [CalendarService].
+class GoldenDayBanner extends StatelessWidget {
+  const GoldenDayBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final calendar = context.read<CalendarService>();
+    return FutureBuilder<DateTime?>(
+      future: calendar.loadUpcomingGoldenDay(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final day = snapshot.data;
+        final text = day == null
+            ? 'Kein Golden Day geplant'
+            : DateFormat('dd.MM.yyyy').format(day);
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Image.asset(
+              'assets/images/paw.png',
+              width: 24,
+              height: 24,
+            ),
+            const SizedBox(width: 8),
+            Text(text),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:bugbear_app/widgets/app_drawer.dart';
 import '../models/reflex_profile.dart';
 import '../services/profile_service.dart';
+import '../../calendar/widgets/golden_day_banner.dart';
 
 class ProfileOverviewScreen extends StatelessWidget {
   const ProfileOverviewScreen({super.key});
@@ -108,10 +109,16 @@ class ProfileOverviewScreen extends StatelessWidget {
                             },
                           ),
                   ),
+                  if (mainId != null)
+                    const Padding(
+                      padding: EdgeInsets.all(16.0),
+                      child: GoldenDayBanner(),
+                    ),
                   Padding(
                     padding: const EdgeInsets.all(16.0),
                     child: ElevatedButton(
-                      onPressed: () => Navigator.pushNamed(context, '/questionnaire'),
+                      onPressed: () =>
+                          Navigator.pushNamed(context, '/questionnaire'),
                       child: const Text('Neues Quiz starten'),
                     ),
                   ),

--- a/lib/features/profile/screens/reflex_profile_detail_screen.dart
+++ b/lib/features/profile/screens/reflex_profile_detail_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/reflex_profile.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
-import '../../calendar/services/calendar_service.dart';
+import '../../calendar/widgets/golden_day_banner.dart';
 
 class ReflexProfileDetailScreen extends StatelessWidget {
   final ReflexProfile profile;
@@ -45,22 +45,7 @@ class ReflexProfileDetailScreen extends StatelessWidget {
             );
           }),
           const SizedBox(height: 24),
-          FutureBuilder<DateTime?>(
-            future: context.read<CalendarService>().loadUpcomingGoldenDay(),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              final day = snapshot.data;
-              final text = day == null
-                  ? 'Kein Golden Day geplant'
-                  : DateFormat('dd.MM.yyyy').format(day);
-              return ListTile(
-                title: const Text('Nächster Golden Day'),
-                trailing: Text(text),
-              );
-            },
-          ),
+          const GoldenDayBanner(),
           const SizedBox(height: 24),
           const Text(
             'Antworten',


### PR DESCRIPTION
## Summary
- add `GoldenDayBanner` widget displaying the next golden day with the paw icon
- show banner on main profile overview and detail screens

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f99cbcdac832da721fa22abdb3d0b