### PR TITLE
Add GoldenDayBanner to calendar screen

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
 import '../widgets/level_map_calendar.dart';
 import '../widgets/month_bracket.dart';
+import '../widgets/golden_day_banner.dart';
 
 import '../models/calendar_event.dart';
 import '../dialogs/edit_training_day_dialog.dart';
@@ -157,6 +158,10 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                 );
               },
             ),
+          ),
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: GoldenDayBanner(),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- display GoldenDayBanner below the calendar grid
- import new widget in `calendar_screen.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa5cb430c832da7b409f3f231ea70