### PR TITLE
Fix today highlight persistence

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -140,7 +140,9 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                         bugDay: notifier.upcomingGoldenDay,
                         showBug: isSelectedMonth,
                         showSelectedHighlight: isSelectedMonth,
-                        showTodayHighlight: isTodayMonth,
+                        // Always highlight the current day number so it
+                        // remains visible when navigating between months.
+                        showTodayHighlight: true,
                         eventLoader: notifier.eventsForDay,
                         onDaySelected: _onDaySelected,
                       ),

--- a/lib/features/calendar/widgets/level_map_calendar.dart
+++ b/lib/features/calendar/widgets/level_map_calendar.dart
@@ -43,6 +43,9 @@ class LevelMapCalendar extends StatelessWidget {
   bool _isSameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
+  bool _isSameDayNumber(DateTime date, int dayNumber) =>
+      date.day == dayNumber && date.month == month.month;
+
   @override
   Widget build(BuildContext context) {
     final firstOfMonth = DateTime(month.year, month.month, 1);
@@ -144,7 +147,7 @@ class LevelMapCalendar extends StatelessWidget {
                                     .withAlpha((0.2 * 255).round())
                                 : null,
                             border: showTodayHighlight &&
-                                    _isSameDay(date, DateTime.now())
+                                    _isSameDayNumber(date, DateTime.now().day)
                                 ? Border.all(
                                     color: scheduledColor,
                                     width: 2,


### PR DESCRIPTION
## Summary
- always pass `showTodayHighlight: true` to highlight the current day number across month views

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685fa820711c832da7757985f3c6e44e