### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -125,8 +125,6 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
                 final month = _monthForIndex(index);
                 final isSelectedMonth =
                     month.year == selectedDay.year && month.month == selectedDay.month;
-                final isTodayMonth =
-                    month.year == DateTime.now().year && month.month == DateTime.now().month;
                 final day = isSelectedMonth
                     ? selectedDay
                     : DateTime(month.year, month.month, 1);


### PR DESCRIPTION
## Summary
- remove unused `isTodayMonth` variable

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fae8c9ec8832db4bdcb8b34a83941