### PR TITLE
Add training help screen with video player

### DIFF
--- a/lib/features/training/screens/training_help_screen.dart
+++ b/lib/features/training/screens/training_help_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:video_player/video_player.dart';
+
+import '../services/exercise_repository.dart';
+
+class TrainingHelpScreen extends StatefulWidget {
+  final String phaseId;
+  const TrainingHelpScreen({super.key, required this.phaseId});
+
+  @override
+  State<TrainingHelpScreen> createState() => _TrainingHelpScreenState();
+}
+
+class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
+  VideoPlayerController? _controller;
+
+  Future<void> _playVideo() async {
+    await _controller?.dispose();
+    _controller = VideoPlayerController.asset('assets/videos/test video.mp4');
+    await _controller!.initialize();
+    setState(() {});
+    await _controller!.play();
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = context.read<ExerciseRepository>();
+    final exercises = repo.getExercisesForPhase(widget.phaseId);
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Phase ${widget.phaseId} Hilfe')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: List.generate(exercises.length, (i) {
+                final num = i + 1;
+                return ElevatedButton(
+                  key: Key('help_btn_\$num'),
+                  onPressed: _playVideo,
+                  child: Text('\$num'),
+                );
+              }),
+            ),
+            const SizedBox(height: 16),
+            if (_controller != null && _controller!.value.isInitialized)
+              AspectRatio(
+                aspectRatio: _controller!.value.aspectRatio,
+                child: VideoPlayer(_controller!),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/training/training_screen.dart
+++ b/lib/features/training/training_screen.dart
@@ -23,9 +23,7 @@ class TrainingScreen extends StatelessWidget {
       drawer: const AppDrawer(),
       appBar: TrainingHeader(
         phaseName: 'Phase ${state.phaseId}',
-        onHelpPressed: () {
-          // TODO: Hilfe-Overlay öffnen
-        },
+        phaseId: state.phaseId,
       ),
       body: Column(
         children: [

--- a/lib/features/training/widgets/training_header.dart
+++ b/lib/features/training/widgets/training_header.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:bugbear_app/features/training/screens/phase_selection_screen.dart';
+import 'package:bugbear_app/features/training/screens/training_help_screen.dart';
 
 /// TrainingHeader zeigt in der oberen Leiste:
 /// - das automatische Hamburger-Icon (öffnet den Drawer)
@@ -7,12 +8,12 @@ import 'package:bugbear_app/features/training/screens/phase_selection_screen.dar
 /// - ein Hilfesymbol (öffnet ein Overlay mit Erklärungen)
 class TrainingHeader extends StatelessWidget implements PreferredSizeWidget {
   final String phaseName;
-  final VoidCallback onHelpPressed;
+  final String phaseId;
 
   const TrainingHeader({
     super.key,
     required this.phaseName,
-    required this.onHelpPressed,
+    required this.phaseId,
   });
 
   @override
@@ -42,7 +43,13 @@ class TrainingHeader extends StatelessWidget implements PreferredSizeWidget {
       actions: [
         IconButton(
           icon: const Icon(Icons.help_outline),
-          onPressed: onHelpPressed,
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => TrainingHelpScreen(phaseId: phaseId),
+              ),
+            );
+          },
           tooltip: 'Hilfe anzeigen',
         ),
       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   json_annotation: ^4.9.0
   freezed_annotation: ^2.1.0
   audioplayers: ^6.4.0
+  video_player: ^2.7.0
 
   # Offline-Persistence mit Hive (inkl. Verschlüsselung)
   hive: ^2.2.3

--- a/test/training_help_screen_test.dart
+++ b/test/training_help_screen_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:bugbear_app/features/training/services/exercise_repository.dart';
+import 'package:bugbear_app/features/training/screens/training_help_screen.dart';
+
+void main() {
+  testWidgets('shows buttons for each exercise', (tester) async {
+    const phase = '1';
+    final repo = ExerciseRepository();
+    final count = repo.getExercisesForPhase(phase).length;
+
+    await tester.pumpWidget(
+      Provider<ExerciseRepository>.value(
+        value: repo,
+        child: const MaterialApp(
+          home: TrainingHelpScreen(phaseId: phase),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.byType(ElevatedButton), findsNWidgets(count));
+  });
+}


### PR DESCRIPTION
## Summary
- add `video_player` dependency
- implement `TrainingHelpScreen` with numbered buttons and video playback
- open help screen from `TrainingHeader`
- wire up `TrainingHeader` with phase id
- add widget test for the help screen

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a7679e38832da7b3246db8cffa66