### PR TITLE
Fix duplicate parameters in TrainingHelpScreen

### DIFF
--- a/lib/features/training/screens/training_help_screen.dart
+++ b/lib/features/training/screens/training_help_screen.dart
@@ -46,15 +46,9 @@ class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
               children: List.generate(exercises.length, (i) {
                 final num = i + 1;
                 return ElevatedButton(
-
                   key: Key('help_btn_$num'),
                   onPressed: _playVideo,
                   child: Text('$num'),
-
-                  key: Key('help_btn_\$num'),
-                  onPressed: _playVideo,
-                  child: Text('\$num'),
-
                 );
               }),
             ),


### PR DESCRIPTION
## Summary
- remove duplicate named parameters in `TrainingHelpScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b61818f0832dac9777a98b1a2611