### PR TITLE
Fix video playback on help screen

### DIFF
--- a/lib/features/training/screens/training_help_screen.dart
+++ b/lib/features/training/screens/training_help_screen.dart
@@ -47,7 +47,7 @@ class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
                 final num = i + 1;
                 return ElevatedButton(
                   key: Key('help_btn_$num'),
-                  onPressed: _playVideo,
+                  onPressed: () => _playVideo(),
                   child: Text('$num'),
                 );
               }),


### PR DESCRIPTION
## Summary
- ensure video playback starts on button press in the help screen

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b8aa4f94832dad3627943d354d76