### PR TITLE
Rename app to Free Base and refresh branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,135 @@
-# bugbear_app
+# Free Base
 
-A cross-platform Flutter application for logging bug reports and managing recovery tasks.
+Free Base is the digital companion for the Free Base reflex-integration program. The Flutter app guides families, athletes, and
+therapists through structured training phases, keeps offline progress safely encrypted, and synchronises results with Firebase so
+coaches always have the latest information.
+
+## Project Overview
+
+### Key Features
+- **Guided onboarding** with Firebase email/password authentication, secure key generation, and role selection for personal,
+  parent/child, or trainer journeys.
+- **Daily training companion** featuring phase-based exercise plans, timers, and offline persistence through Hive, with automatic
+  background synchronisation handled by the `SyncService` once connectivity returns.
+- **Calendar and “Golden Day” planning** powered by the `CalendarService` and `GoldenDayService` to monitor adherence and highlight
+  milestone celebrations.
+- **Questionnaire and reflex profiles** that pull structured content from local JSON assets, store state securely, and surface
+  insights through the profile screens.
+- **Cross-platform shell** with platform-specific assets (icons, splash screens) ready to be replaced with branded Free Base
+  artwork.
+
+### Architecture Highlights
+- Flutter 3 / Dart 3 application organised under `lib/features`, using Provider for dependency injection and state management.
+- Firebase Core, Authentication, and Firestore for backend services; configuration is generated via `firebase_options.dart` and
+  platform-specific files created by `flutterfire configure`.
+- Hive (AES encrypted via `SecureStorageService`) for offline-first storage of training sessions, questionnaires, and calendar
+  events.
+- Modular services (`SessionRepository`, `ExerciseRepository`, `SyncService`, `CalendarService`, `GoldenDayService`,
+  `ProfileService`) that keep UI widgets declarative and easy to test.
+- Localisation scaffolding (`lib/l10n/*.arb`) prepared for English and German with the shared `appName` key.
 
 ## Getting Started
 
-This project is a starting point for a Flutter application.
+### Prerequisites
+- Flutter SDK 3.0 or newer (verify with `flutter --version`).
+- Dart 3 toolchain (included with Flutter).
+- Firebase CLI (`npm install -g firebase-tools`) with access to a Firebase project.
+- Platform SDKs for your targets (Android Studio, Xcode, Visual Studio Build Tools).
 
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-
-## Firestore Rules
-
-Security rules for Cloud Firestore are stored in `firestore.rules`. After making changes, deploy them with other Firebase configuration using:
-
+### 1. Clone & install dependencies
 ```bash
-firebase deploy
+git clone https://github.com/<your-org>/free-base.git
+cd free-base
+flutter pub get
 ```
 
-## Encryption Key Lifecycle
+### 2. Configure Firebase (EU region)
+1. Create a Firebase project or reuse an existing one. When enabling Firestore and Storage, choose an EU region such as
+   `europe-west1` to keep personal data inside the EU.
+2. Run the FlutterFire wizard and select the platforms you need:
+   ```bash
+   flutterfire configure --project <firebase-project-id> --out=lib/firebase_options.dart
+   ```
+3. Restrict the generated API keys to the package and bundle identifiers found in the Android, iOS, macOS, web, and Windows
+   folders. Update `android/app/build.gradle.kts` and `ios/Runner.xcodeproj` if you rename bundle IDs.
+4. Deploy the provided Firestore security rules from `firestore.rules` with `firebase deploy --only firestore:rules`.
 
-The app encrypts all Hive boxes using a secret key. The first time the
-application runs, `SecureStorageService` generates a new key using `Hive.generateSecureKey()`.
-This key is persisted with `FlutterSecureStorage` so it remains available across
-app restarts. On subsequent launches the stored key is loaded again and reused to
-decrypt the boxes. The key only changes when the app data is cleared or the
-`FlutterSecureStorage` entry is removed.
-Signing out triggers `AuthService.signOut()`, which clears `SecureStorageService`
-and deletes the stored encryption key so a fresh key is generated on the next
-launch.
+### 3. Environment configuration
+Sensitive values are injected at build time via `--dart-define`. Configure them once in your shell, CI pipeline, or IDE run
+configuration.
 
-## Firebase API Key Restrictions
-Run `flutterfire configure` to generate `lib/firebase_options.dart` and platform
-specific configuration files. The API keys referenced there are restricted to
-the app's domains and bundle identifiers and may only be used by this
-application. When generating new keys, apply the following restrictions:
+| Key | Purpose |
+| --- | --- |
+| `FIREBASE_PROJECT_ID` | Firebase project identifier (used for desktop builds). |
+| `FIREBASE_ANDROID_API_KEY`, `FIREBASE_ANDROID_APP_ID`, `FIREBASE_ANDROID_MESSAGING_SENDER_ID`, `FIREBASE_ANDROID_STORAGE_BUCKET` |
+  Android credentials as generated by FlutterFire. |
+| `FIREBASE_IOS_*` / `FIREBASE_MACOS_*` | Keys, bundle IDs, and storage buckets for Apple platforms. |
+| `FIREBASE_WEB_*` | Web API key, app ID, auth domain, messaging sender ID, storage bucket. |
+| `FIREBASE_WINDOWS_*` | API key, app ID, auth domain, messaging sender ID, storage bucket for Windows builds. |
 
-1. **Android** – Restrict to the Android package name
-   `com.example.bugbear_app` and add the appropriate SHA-1/SHA-256 signing
-   certificate fingerprints.
-2. **iOS** – Restrict to the bundle ID `com.example.bugbearRecovery`.
-3. **Web** – Authorize the domains used by the web app such as
-   `https://bugbear-9d720.web.app`, `https://bugbear-9d720.firebaseapp.com` and
-   any local development hosts (for example `http://localhost:5000`).
-
-After creating restricted keys, provide them as compile‑time environment
-variables when building the app. The values are read using `String.fromEnvironment`
-and are **not** stored in source control. For web and desktop builds supply the
-values via `--dart-define=FIREBASE_…`. Example:
-
+Example run command:
 ```bash
 flutter run \
-  --dart-define=FIREBASE_PROJECT_ID=bugbear-9d720 \
+  --dart-define=FIREBASE_PROJECT_ID=<project-id> \
   --dart-define=FIREBASE_ANDROID_API_KEY=<android-key> \
   --dart-define=FIREBASE_ANDROID_APP_ID=<android-app-id> \
-  --dart-define=FIREBASE_ANDROID_MESSAGING_SENDER_ID=<android-messaging-id> \
+  --dart-define=FIREBASE_ANDROID_MESSAGING_SENDER_ID=<android-sender-id> \
   --dart-define=FIREBASE_ANDROID_STORAGE_BUCKET=<android-bucket> \
   --dart-define=FIREBASE_IOS_API_KEY=<ios-key> \
   --dart-define=FIREBASE_IOS_APP_ID=<ios-app-id> \
   --dart-define=FIREBASE_IOS_BUNDLE_ID=<ios-bundle-id> \
-  --dart-define=FIREBASE_IOS_MESSAGING_SENDER_ID=<ios-messaging-id> \
+  --dart-define=FIREBASE_IOS_MESSAGING_SENDER_ID=<ios-sender-id> \
   --dart-define=FIREBASE_IOS_STORAGE_BUCKET=<ios-bucket> \
   --dart-define=FIREBASE_MACOS_API_KEY=<macos-key> \
   --dart-define=FIREBASE_MACOS_APP_ID=<macos-app-id> \
   --dart-define=FIREBASE_MACOS_BUNDLE_ID=<macos-bundle-id> \
-  --dart-define=FIREBASE_MACOS_MESSAGING_SENDER_ID=<macos-messaging-id> \
+  --dart-define=FIREBASE_MACOS_MESSAGING_SENDER_ID=<macos-sender-id> \
   --dart-define=FIREBASE_MACOS_STORAGE_BUCKET=<macos-bucket> \
   --dart-define=FIREBASE_WEB_API_KEY=<web-key> \
   --dart-define=FIREBASE_WEB_APP_ID=<web-app-id> \
   --dart-define=FIREBASE_WEB_AUTH_DOMAIN=<web-auth-domain> \
-  --dart-define=FIREBASE_WEB_MESSAGING_SENDER_ID=<web-messaging-id> \
+  --dart-define=FIREBASE_WEB_MESSAGING_SENDER_ID=<web-sender-id> \
   --dart-define=FIREBASE_WEB_STORAGE_BUCKET=<web-bucket> \
   --dart-define=FIREBASE_WINDOWS_API_KEY=<windows-key> \
   --dart-define=FIREBASE_WINDOWS_APP_ID=<windows-app-id> \
   --dart-define=FIREBASE_WINDOWS_AUTH_DOMAIN=<windows-auth-domain> \
-  --dart-define=FIREBASE_WINDOWS_MESSAGING_SENDER_ID=<windows-messaging-id> \
+  --dart-define=FIREBASE_WINDOWS_MESSAGING_SENDER_ID=<windows-sender-id> \
   --dart-define=FIREBASE_WINDOWS_STORAGE_BUCKET=<windows-bucket>
 ```
 
-Missing values for any of these variables cause `Firebase.initializeApp` to fail
-during startup.
+Tip: For local development create a script (e.g. `tool/run_free_base.sh`) that exports these values or use `.vscode/launch.json`
+with per-platform configurations.
 
-These variables can also be configured in your CI environment with the same
-names when running `flutter build`.
+### 4. Run smoke tests
+- `flutter run` (mobile/web/desktop) — verify the splash screen, login, and dashboard navigation flows.
+- `flutter test` — execute unit and widget tests (including questionnaire and golden day services).
+- `npm test` inside the project root — runs Firestore security rule tests.
+
+### Build & Release
+- Android: `flutter build apk` / `flutter build appbundle`.
+- iOS: `flutter build ios --release` (requires Xcode setup and code signing).
+- Web: `flutter build web` and deploy the contents of `build/web/`.
+- macOS / Windows: `flutter build macos` or `flutter build windows` (make sure the generated binaries use the Free Base name).
+
+Replace the placeholder launcher icons and splash screens with official Free Base artwork before shipping. Assets live under
+`assets/images` and platform-specific resources (`android/app/src/main/res`, `ios/Runner/Assets.xcassets`, etc.).
+
+## Privacy & Data Protection (EU)
+- Store all Firebase services in an EU region and document the data flows in your privacy policy.
+- Authentication credentials are handled by Firebase Auth; training data and questionnaire answers live in Firestore collections
+  scoped to the user ID.
+- Local Hive boxes are encrypted with an AES key stored via `SecureStorageService` and purged on sign-out.
+- Update the in-app and store privacy disclosures to explain retention periods, user deletion rights, and data processing roles.
+
+## Maintenance & Tooling
+- Generate localisation files with `flutter pub run intl_utils:generate` after editing `.arb` resources.
+- Run `flutter pub run build_runner build --delete-conflicting-outputs` if you add new `freezed` or `json_serializable`
+  models.
+- Keep the Firebase configuration (`lib/firebase_options.dart` and platform bundles) in sync with the project when environments
+  change.
+
+## Known Issues
+- Parent and trainer role flows still use placeholder screens. UX copy and dedicated dashboards will follow in future sprints.
+- Exercise assets currently rely on placeholder imagery (`assets/images/placeholder.png`). Replace these with the final Free Base
+  visuals during the branding pass.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="bugbear_recovery"
+        android:label="Free Base"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,16 +4,16 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>Bugbear Recovery</string>
+        <key>CFBundleDisplayName</key>
+        <string>Free Base</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>bugbear_recovery</string>
+        <key>CFBundleName</key>
+        <string>Free Base</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -1,0 +1,11 @@
+/// Centralized application copy used across widgets and platform shells.
+class AppStrings {
+  const AppStrings._();
+
+  /// Primary product name displayed across all platforms.
+  static const String appName = 'Free Base';
+
+  /// Short description used in marketing copy and metadata.
+  static const String appTagline =
+      'Reflex-integration training made accessible for every family.';
+}

--- a/lib/features/calendar/models/calendar_event.dart
+++ b/lib/features/calendar/models/calendar_event.dart
@@ -1,7 +1,7 @@
 // lib/features/calendar/models/calendar_event.dart
 
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:bugbear_app/features/training/models/session_state.dart';
+import 'package:free_base/features/training/models/session_state.dart';
 
 part 'calendar_event.freezed.dart';
 part 'calendar_event.g.dart';

--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -11,7 +11,7 @@ import '../models/calendar_event.dart';
 import '../dialogs/edit_training_day_dialog.dart';
 import '../notifier/calendar_notifier.dart';
 import '../services/calendar_service.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 
 /// CalendarScreen
 ///

--- a/lib/features/calendar/services/calendar_service.dart
+++ b/lib/features/calendar/services/calendar_service.dart
@@ -1,7 +1,7 @@
 // lib/features/calendar/services/calendar_service.dart
 
 import 'package:hive/hive.dart';
-import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
+import 'package:free_base/features/calendar/models/calendar_event.dart';
 
 /// CalendarService
 ///

--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -1,9 +1,9 @@
 // lib/features/common/dashboard_screen.dart
 
 import 'package:flutter/material.dart';
-import 'package:bugbear_app/features/training/training_screen.dart';
-import 'package:bugbear_app/features/calendar/screens/calendar_screen.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/features/training/training_screen.dart';
+import 'package:free_base/features/calendar/screens/calendar_screen.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 
 /// DashboardScreen
 ///

--- a/lib/features/common/splash_screen.dart
+++ b/lib/features/common/splash_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:bugbear_app/features/onboarding/services/secure_storage_service.dart';
+import 'package:free_base/features/onboarding/services/secure_storage_service.dart';
 
 /// SplashScreen: Prüft verschlüsselten Login-Status + Firebase-Auth
 class SplashScreen extends StatefulWidget {

--- a/lib/features/onboarding/profile/settings_screen.dart
+++ b/lib/features/onboarding/profile/settings_screen.dart
@@ -2,8 +2,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/features/onboarding/services/auth_service.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/features/onboarding/services/auth_service.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});

--- a/lib/features/onboarding/screens/login_screen.dart
+++ b/lib/features/onboarding/screens/login_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/features/onboarding/services/auth_service.dart';
+import 'package:free_base/features/onboarding/services/auth_service.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});

--- a/lib/features/onboarding/screens/register_screen.dart
+++ b/lib/features/onboarding/screens/register_screen.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/features/onboarding/services/auth_service.dart';
+import 'package:free_base/features/onboarding/services/auth_service.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});

--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 import '../models/reflex_profile.dart';
 import '../services/profile_service.dart';
 import '../../calendar/widgets/golden_day_banner.dart';

--- a/lib/features/questionnaire/questionnaire_screen.dart
+++ b/lib/features/questionnaire/questionnaire_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:hive/hive.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 
 import 'questionnaire_state.dart';
 import 'questionnaire_result_screen.dart';

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -5,8 +5,8 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:hive/hive.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:bugbear_app/features/profile/models/reflex_profile.dart';
-import 'package:bugbear_app/features/profile/services/profile_service.dart';
+import 'package:free_base/features/profile/models/reflex_profile.dart';
+import 'package:free_base/features/profile/services/profile_service.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'dart:developer' as developer;
 

--- a/lib/features/questionnaire/quiz_intro_screen.dart
+++ b/lib/features/questionnaire/quiz_intro_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 
 import 'questionnaire_state.dart';
 

--- a/lib/features/training/models/session_state_adapter.dart
+++ b/lib/features/training/models/session_state_adapter.dart
@@ -1,5 +1,5 @@
 import 'package:hive/hive.dart';
-import 'package:bugbear_app/features/training/models/session_state.dart';
+import 'package:free_base/features/training/models/session_state.dart';
 
 class SessionStatusAdapter extends TypeAdapter<SessionStatus> {
   @override

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -8,14 +8,14 @@
 
 import 'dart:async';
 import 'package:flutter/foundation.dart';
-import 'package:bugbear_app/features/training/models/session_state.dart';
-import 'package:bugbear_app/features/training/models/exercise_item.dart';
-import 'package:bugbear_app/features/training/services/session_repository.dart';
-import 'package:bugbear_app/features/training/services/sync_service.dart';
-import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
-import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
-import 'package:bugbear_app/features/training/services/exercise_repository.dart';
-import 'package:bugbear_app/features/calendar/services/golden_day_service.dart';
+import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/features/training/models/exercise_item.dart';
+import 'package:free_base/features/training/services/session_repository.dart';
+import 'package:free_base/features/training/services/sync_service.dart';
+import 'package:free_base/features/calendar/services/calendar_service.dart';
+import 'package:free_base/features/calendar/models/calendar_event.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/calendar/services/golden_day_service.dart';
 
 class SessionNotifier extends ChangeNotifier {
   final SessionRepository _repo;

--- a/lib/features/training/screens/phase_selection_screen.dart
+++ b/lib/features/training/screens/phase_selection_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/features/training/services/exercise_repository.dart';
-import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/widgets/app_drawer.dart';
 
 class PhaseSelectionScreen extends StatelessWidget {
   const PhaseSelectionScreen({super.key});

--- a/lib/features/training/services/exercise_repository.dart
+++ b/lib/features/training/services/exercise_repository.dart
@@ -1,4 +1,4 @@
-import 'package:bugbear_app/features/training/models/exercise_item.dart';
+import 'package:free_base/features/training/models/exercise_item.dart';
 
 /// Liefert für eine gegebene Phase eine Liste nummerierter ExerciseItems.
 class ExerciseRepository {

--- a/lib/features/training/services/session_repository.dart
+++ b/lib/features/training/services/session_repository.dart
@@ -1,6 +1,6 @@
 // lib/features/training/services/session_repository.dart
 
-import 'package:bugbear_app/features/training/models/session_state.dart';
+import 'package:free_base/features/training/models/session_state.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 class SessionRepository {

--- a/lib/features/training/services/sync_service.dart
+++ b/lib/features/training/services/sync_service.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:bugbear_app/features/training/models/session_state.dart';
-import 'package:bugbear_app/features/training/services/session_repository.dart';
+import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/features/training/services/session_repository.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class SyncService {

--- a/lib/features/training/training_screen.dart
+++ b/lib/features/training/training_screen.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
-import 'package:bugbear_app/features/training/widgets/training_header.dart';
-import 'package:bugbear_app/widgets/app_drawer.dart';
-import 'package:bugbear_app/features/training/widgets/progress_row.dart';
-import 'package:bugbear_app/features/training/widgets/exercise_canvas.dart';
-import 'package:bugbear_app/features/training/widgets/control_button_row.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/widgets/training_header.dart';
+import 'package:free_base/widgets/app_drawer.dart';
+import 'package:free_base/features/training/widgets/progress_row.dart';
+import 'package:free_base/features/training/widgets/exercise_canvas.dart';
+import 'package:free_base/features/training/widgets/control_button_row.dart';
 
 class TrainingScreen extends StatelessWidget {
   const TrainingScreen({super.key});

--- a/lib/features/training/widgets/phase_selection_dialog.dart
+++ b/lib/features/training/widgets/phase_selection_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/features/training/services/exercise_repository.dart';
-import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
 
 class PhaseSelectionDialog extends StatelessWidget {
   const PhaseSelectionDialog({super.key});

--- a/lib/features/training/widgets/training_header.dart
+++ b/lib/features/training/widgets/training_header.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:bugbear_app/features/training/screens/phase_selection_screen.dart';
-import 'package:bugbear_app/features/training/screens/training_help_screen.dart';
+import 'package:free_base/features/training/screens/phase_selection_screen.dart';
+import 'package:free_base/features/training/screens/training_help_screen.dart';
 
 /// TrainingHeader zeigt in der oberen Leiste:
 /// - das automatische Hamburger-Icon (öffnet den Drawer)

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,0 +1,7 @@
+{
+  "@@locale": "de",
+  "appName": "Free Base",
+  "@appName": {
+    "description": "Produktname der Free Base Anwendung."
+  }
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,7 @@
+{
+  "@@locale": "en",
+  "appName": "Free Base",
+  "@appName": {
+    "description": "Brand name of the Free Base application."
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,36 +5,37 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-import 'package:bugbear_app/firebase_options.dart';
-import 'package:bugbear_app/features/onboarding/services/auth_service.dart';
-import 'package:bugbear_app/features/onboarding/services/secure_storage_service.dart';
-import 'package:bugbear_app/features/onboarding/state/auth_provider.dart';
-import 'package:bugbear_app/features/common/splash_screen.dart';
-import 'package:bugbear_app/features/onboarding/screens/login_screen.dart';
-import 'package:bugbear_app/features/onboarding/screens/register_screen.dart';
-import 'package:bugbear_app/features/onboarding/screens/role_selection_screen.dart';
-import 'package:bugbear_app/features/common/dashboard_screen.dart';
-import 'package:bugbear_app/features/onboarding/profile/settings_screen.dart';
-import 'package:bugbear_app/features/training/training_screen.dart';
-import 'package:bugbear_app/features/calendar/screens/calendar_screen.dart';
-import 'package:bugbear_app/features/common/error_screen.dart';
+import 'package:free_base/constants/app_strings.dart';
+import 'package:free_base/firebase_options.dart';
+import 'package:free_base/features/onboarding/services/auth_service.dart';
+import 'package:free_base/features/onboarding/services/secure_storage_service.dart';
+import 'package:free_base/features/onboarding/state/auth_provider.dart';
+import 'package:free_base/features/common/splash_screen.dart';
+import 'package:free_base/features/onboarding/screens/login_screen.dart';
+import 'package:free_base/features/onboarding/screens/register_screen.dart';
+import 'package:free_base/features/onboarding/screens/role_selection_screen.dart';
+import 'package:free_base/features/common/dashboard_screen.dart';
+import 'package:free_base/features/onboarding/profile/settings_screen.dart';
+import 'package:free_base/features/training/training_screen.dart';
+import 'package:free_base/features/calendar/screens/calendar_screen.dart';
+import 'package:free_base/features/common/error_screen.dart';
 
-import 'package:bugbear_app/features/training/models/session_state.dart';
-import 'package:bugbear_app/features/training/models/session_state_adapter.dart';
-import 'package:bugbear_app/features/training/services/session_repository.dart';
-import 'package:bugbear_app/features/training/services/sync_service.dart';
-import 'package:bugbear_app/features/training/services/exercise_repository.dart';
-import 'package:bugbear_app/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/features/training/models/session_state_adapter.dart';
+import 'package:free_base/features/training/services/session_repository.dart';
+import 'package:free_base/features/training/services/sync_service.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
 
-import 'package:bugbear_app/features/calendar/models/calendar_event.dart';
-import 'package:bugbear_app/features/calendar/models/calendar_event_adapter.dart';
-import 'package:bugbear_app/features/calendar/services/calendar_service.dart';
-import 'package:bugbear_app/features/calendar/services/golden_day_service.dart';
-import 'package:bugbear_app/features/questionnaire/questionnaire_screen.dart';
-import 'package:bugbear_app/features/questionnaire/quiz_intro_screen.dart';
-import 'package:bugbear_app/features/profile/screens/profile_overview_screen.dart';
-import 'package:bugbear_app/features/profile/screens/reflex_profile_detail_screen.dart';
-import 'package:bugbear_app/features/profile/models/reflex_profile.dart';
+import 'package:free_base/features/calendar/models/calendar_event.dart';
+import 'package:free_base/features/calendar/models/calendar_event_adapter.dart';
+import 'package:free_base/features/calendar/services/calendar_service.dart';
+import 'package:free_base/features/calendar/services/golden_day_service.dart';
+import 'package:free_base/features/questionnaire/questionnaire_screen.dart';
+import 'package:free_base/features/questionnaire/quiz_intro_screen.dart';
+import 'package:free_base/features/profile/screens/profile_overview_screen.dart';
+import 'package:free_base/features/profile/screens/reflex_profile_detail_screen.dart';
+import 'package:free_base/features/profile/models/reflex_profile.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -162,7 +163,7 @@ class MyApp extends StatelessWidget {
         createQuestionnaireProvider(),
       ],
       child: MaterialApp(
-        title: 'BugBear App',
+        title: AppStrings.appName,
         theme: ThemeData(primarySwatch: Colors.blue),
         initialRoute: '/',
         routes: {

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:bugbear_app/features/training/screens/phase_selection_screen.dart';
+import 'package:free_base/constants/app_strings.dart';
+import 'package:free_base/features/training/screens/phase_selection_screen.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({super.key});
@@ -11,11 +12,26 @@ class AppDrawer extends StatelessWidget {
         child: ListView(
           padding: EdgeInsets.zero,
           children: [
-            const DrawerHeader(
+            DrawerHeader(
               decoration: BoxDecoration(color: Colors.blueGrey),
-              child: Text(
-                'Menü',
-                style: TextStyle(fontSize: 24, color: Colors.white),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    AppStrings.appName,
+                    style: const TextStyle(
+                      fontSize: 24,
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Menü',
+                    style: const TextStyle(fontSize: 16, color: Colors.white70),
+                  ),
+                ],
               ),
             ),
             ListTile(

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* bugbear_recovery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "bugbear_recovery.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* Free Base.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Free Base.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* bugbear_recovery.app */,
+				33CC10ED2044A3C60003C045 /* Free Base.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* bugbear_recovery.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* Free Base.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -388,7 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.bugbearRecovery.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bugbear_recovery.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/bugbear_recovery";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Free Base.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Free Base";
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.bugbearRecovery.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bugbear_recovery.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/bugbear_recovery";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Free Base.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Free Base";
 			};
 			name = Release;
 		};
@@ -416,7 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.bugbearRecovery.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bugbear_recovery.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/bugbear_recovery";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Free Base.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Free Base";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "bugbear_recovery.app"
+               BuildableName = "Free Base.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "bugbear_recovery.app"
+            BuildableName = "Free Base.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "bugbear_recovery.app"
+            BuildableName = "Free Base.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "bugbear_recovery.app"
+            BuildableName = "Free Base.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = bugbear_recovery
+PRODUCT_NAME = Free Base
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.bugbearRecovery

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
-name: bugbear_app
-description: "A visionary Flutter project, built with passion and innovative flair."
+name: free_base
+description: "The Free Base companion app for planning, training, and tracking reflex integration."
 
 publish_to: 'none'
 version: 1.0.0+1

--- a/test/golden_day_test.dart
+++ b/test/golden_day_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:bugbear_app/features/calendar/services/golden_day_service.dart';
+import 'package:free_base/features/calendar/services/golden_day_service.dart';
 
 void main() {
   final service = GoldenDayService();

--- a/test/training_help_screen_test.dart
+++ b/test/training_help_screen_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:bugbear_app/features/training/services/exercise_repository.dart';
-import 'package:bugbear_app/features/training/screens/training_help_screen.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/training/screens/training_help_screen.dart';
 
 void main() {
   testWidgets('shows buttons for each exercise', (tester) async {

--- a/web/index.html
+++ b/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Free Base helps families coordinate reflex-integration training across home and therapy.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="bugbear_recovery">
+  <meta name="apple-mobile-web-app-title" content="Free Base">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>bugbear_recovery</title>
+  <title>Free Base</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "bugbear_recovery",
-    "short_name": "bugbear_recovery",
+    "name": "Free Base",
+    "short_name": "FreeBase",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "description": "Free Base helps families plan, execute, and track reflex-integration training sessions.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(bugbear_recovery LANGUAGES CXX)
+project(free_base LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "bugbear_recovery")
+set(BINARY_NAME "free_base")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "bugbear_recovery" "\0"
+            VALUE "FileDescription", "Free Base" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "bugbear_recovery" "\0"
+            VALUE "InternalName", "free_base" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "bugbear_recovery.exe" "\0"
-            VALUE "ProductName", "bugbear_recovery" "\0"
+            VALUE "OriginalFilename", "free_base.exe" "\0"
+            VALUE "ProductName", "Free Base" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"bugbear_recovery", origin, size)) {
+  if (!window.Create(L"Free Base", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- rename the Flutter package to `free_base`, add a central `AppStrings` helper, and update imports/widgets to surface the Free Base name
- refresh the README with the new product positioning, setup steps, and EU privacy notes
- align Android, iOS, web, macOS, and Windows metadata plus localisation files with the Free Base branding

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c85ec4af10832d95d63dad2012b5ee