### PR TITLE
Add feature flags, unified error handling, and tests

### DIFF
--- a/lib/features/common/feature_placeholder_screen.dart
+++ b/lib/features/common/feature_placeholder_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:free_base/widgets/app_drawer.dart';
+
+/// Generic placeholder screen that communicates disabled or upcoming
+/// functionality. It can be reused for feature-flagged sections so that we
+/// don't have to scatter ad-hoc scaffold implementations throughout the app.
+class FeaturePlaceholderScreen extends StatelessWidget {
+  final String title;
+  final String message;
+
+  const FeaturePlaceholderScreen({
+    super.key,
+    required this.title,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      drawer: const AppDrawer(),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Text(
+            message,
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/screens/login_screen.dart
+++ b/lib/features/onboarding/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:free_base/features/onboarding/services/auth_service.dart';
+import 'package:free_base/services/error_handler.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -37,9 +38,19 @@ class LoginScreenState extends State<LoginScreen> {
       Navigator.pushReplacementNamed(context, '/select-role');
     } catch (e) {
       if (!mounted) return;
+      final locale = Localizations.maybeLocaleOf(context);
+      final isGerman = locale != null && locale.languageCode.toLowerCase() == 'de';
+      final message = ErrorHandler.messageFor(
+        e,
+        isGerman: isGerman,
+        fallback: isGerman
+            ? 'Fehler bei der Anmeldung. Bitte später erneut versuchen.'
+            : 'Login failed. Please try again later.',
+      );
       setState(() {
-        _error = 'Fehler bei der Anmeldung: ${e.toString()}';
+        _error = message;
       });
+      ErrorHandler.showErrorSnack(context, message);
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }

--- a/lib/features/onboarding/screens/register_screen.dart
+++ b/lib/features/onboarding/screens/register_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:free_base/features/onboarding/services/auth_service.dart';
+import 'package:free_base/services/error_handler.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -41,9 +42,19 @@ class RegisterScreenState extends State<RegisterScreen> {
       Navigator.pushReplacementNamed(context, '/select-role');
     } catch (e) {
       if (!mounted) return;
+      final locale = Localizations.maybeLocaleOf(context);
+      final isGerman = locale != null && locale.languageCode.toLowerCase() == 'de';
+      final message = ErrorHandler.messageFor(
+        e,
+        isGerman: isGerman,
+        fallback: isGerman
+            ? 'Fehler beim Registrieren. Bitte später erneut versuchen.'
+            : 'Registration failed. Please try again later.',
+      );
       setState(() {
-        _error = 'Fehler beim Registrieren: ${e.toString()}';
+        _error = message;
       });
+      ErrorHandler.showErrorSnack(context, message);
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }

--- a/lib/features/onboarding/screens/role_selection_screen.dart
+++ b/lib/features/onboarding/screens/role_selection_screen.dart
@@ -1,6 +1,10 @@
-import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/services/error_handler.dart';
+import 'package:free_base/services/feature_flags.dart';
 
 class RoleSelectionScreen extends StatefulWidget {
   const RoleSelectionScreen({super.key});
@@ -37,29 +41,12 @@ class RoleSelectionScreenState extends State<RoleSelectionScreen> {
       Navigator.pushReplacementNamed(context, '/dashboard');
     } catch (e) {
       if (!mounted) return;
-
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content:
-                Text('Fehler beim Speichern der Rolle. Bitte später erneut versuchen.'),
-            backgroundColor: Colors.red,
-          ),
-        );
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Fehler beim Speichern der Rolle. Bitte später erneut versuchen.'),
-          backgroundColor: Colors.red,
-        ),
+      ErrorHandler.showError(
+        context,
+        e,
+        fallback:
+            'Fehler beim Speichern der Rolle. Bitte später erneut versuchen.',
       );
-
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Fehler beim Speichern der Rolle. Bitte später erneut versuchen.'),
-            backgroundColor: Colors.red,
-          ),
-        );
-
     } finally {
       if (mounted) {
         setState(() {
@@ -71,6 +58,32 @@ class RoleSelectionScreenState extends State<RoleSelectionScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final featureFlags = context.watch<FeatureFlags>();
+    final buttons = <Widget>[
+      _RoleButton(
+        label: 'Personal',
+        onPressed:
+            _isLoading ? null : () => _setRoleAndContinue('personal'),
+      ),
+      if (featureFlags.parentsTrackEnabled) ...[
+        const SizedBox(height: 12),
+        _RoleButton(
+          label: 'Eltern-Kind',
+          onPressed: _isLoading
+              ? null
+              : () => _setRoleAndContinue('eltern-kind'),
+        ),
+      ],
+      if (featureFlags.trainerTrackEnabled) ...[
+        const SizedBox(height: 12),
+        _RoleButton(
+          label: 'Trainer',
+          onPressed:
+              _isLoading ? null : () => _setRoleAndContinue('trainer'),
+        ),
+      ],
+    ];
+
     return Scaffold(
       appBar: AppBar(title: const Text('Rolle auswählen')),
       body: Padding(
@@ -80,24 +93,27 @@ class RoleSelectionScreenState extends State<RoleSelectionScreen> {
               ? const CircularProgressIndicator()
               : Column(
                   mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    ElevatedButton(
-                      onPressed: () => _setRoleAndContinue('personal'),
-                      child: const Text('Personal'),
-                    ),
-                    const SizedBox(height: 12),
-                    ElevatedButton(
-                      onPressed: () => _setRoleAndContinue('eltern-kind'),
-                      child: const Text('Eltern-Kind'),
-                    ),
-                    const SizedBox(height: 12),
-                    ElevatedButton(
-                      onPressed: () => _setRoleAndContinue('trainer'),
-                      child: const Text('Trainer'),
-                    ),
-                  ],
+                  children: buttons,
                 ),
         ),
+      ),
+    );
+  }
+}
+
+class _RoleButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+
+  const _RoleButton({required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: Text(label),
       ),
     );
   }

--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:free_base/services/error_handler.dart';
+
 import 'questionnaire_state.dart';
 
 /// Displays questionnaire results with percentages per reflex and allows
@@ -63,12 +65,16 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
       );
     } catch (e) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Fehler beim Speichern des Profils: $e'),
-          backgroundColor: Colors.red,
-        ),
+      final locale = Localizations.maybeLocaleOf(context);
+      final isGerman = locale != null && locale.languageCode.toLowerCase() == 'de';
+      final message = ErrorHandler.messageFor(
+        e,
+        isGerman: isGerman,
+        fallback: isGerman
+            ? 'Fehler beim Speichern des Profils. Bitte erneut versuchen.'
+            : 'Failed to save the profile. Please try again.',
       );
+      ErrorHandler.showErrorSnack(context, message);
     } finally {
       if (mounted) setState(() => _isSaving = false);
     }

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -7,6 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:free_base/features/profile/models/reflex_profile.dart';
 import 'package:free_base/features/profile/services/profile_service.dart';
+import 'package:free_base/services/error_handler.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'dart:developer' as developer;
 
@@ -192,11 +193,10 @@ class QuestionnaireState extends ChangeNotifier {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) {
       if (context != null && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Bitte anmelden, um das Profil zu speichern.'),
-          ),
-        );
+        final message = _isGerman
+            ? 'Bitte anmelden, um das Profil zu speichern.'
+            : 'Please sign in to save the profile.';
+        ErrorHandler.showErrorSnack(context, message);
       }
       return;
     }
@@ -252,21 +252,15 @@ class QuestionnaireState extends ChangeNotifier {
         );
       }
       if (context != null && context.mounted) {
-        var message = _isGerman
+        final fallback = _isGerman
             ? 'Fehler beim Speichern. Bitte erneut versuchen.'
             : 'Error saving. Please try again.';
-        if (e.code == 'permission-denied') {
-          message = _isGerman
-              ? 'Zugriff verweigert. Bitte anmelden.'
-              : 'Permission denied. Please sign in.';
-        } else if (e.code == 'unavailable' || e.code == 'network-error') {
-          message = _isGerman
-              ? 'Netzwerkfehler. Bitte Verbindung prüfen.'
-              : 'Network error. Please check your connection.';
-        }
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(message)),
+        final message = ErrorHandler.messageFor(
+          e,
+          isGerman: _isGerman,
+          fallback: fallback,
         );
+        ErrorHandler.showErrorSnack(context, message);
       }
     } catch (e, st) {
       if (kDebugMode) {
@@ -280,9 +274,7 @@ class QuestionnaireState extends ChangeNotifier {
         final message = _isGerman
             ? 'Fehler beim Speichern. Bitte erneut versuchen.'
             : 'Error saving. Please try again.';
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(message)),
-        );
+        ErrorHandler.showErrorSnack(context, message);
       }
     }
   }

--- a/lib/features/training/training_screen.dart
+++ b/lib/features/training/training_screen.dart
@@ -7,6 +7,7 @@ import 'package:free_base/widgets/app_drawer.dart';
 import 'package:free_base/features/training/widgets/progress_row.dart';
 import 'package:free_base/features/training/widgets/exercise_canvas.dart';
 import 'package:free_base/features/training/widgets/control_button_row.dart';
+import 'package:free_base/widgets/connectivity_banner.dart';
 
 class TrainingScreen extends StatelessWidget {
   const TrainingScreen({super.key});
@@ -27,6 +28,7 @@ class TrainingScreen extends StatelessWidget {
       ),
       body: Column(
         children: [
+          const ConnectivityBanner(),
           ProgressRow(
             currentExercise: idx + 1,
             totalExercises: exercises.length,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,15 @@ import 'package:free_base/features/questionnaire/quiz_intro_screen.dart';
 import 'package:free_base/features/profile/screens/profile_overview_screen.dart';
 import 'package:free_base/features/profile/screens/reflex_profile_detail_screen.dart';
 import 'package:free_base/features/profile/models/reflex_profile.dart';
+import 'package:free_base/features/common/feature_placeholder_screen.dart';
+import 'package:free_base/services/feature_flags.dart';
+
+const FeatureFlags _localFeatureFlags = FeatureFlags(
+  parentsTrackEnabled: true,
+  trainerTrackEnabled: true,
+  forumEnabled: false,
+  achievementsEnabled: false,
+);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -119,6 +128,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        Provider<FeatureFlags>.value(
+          value: _localFeatureFlags,
+        ),
         ChangeNotifierProvider<AppAuthProvider>(
           create: (_) => AppAuthProvider(),
         ),
@@ -208,6 +220,42 @@ class MyApp extends StatelessWidget {
                 final profile = settings.arguments as ReflexProfile;
                 return ReflexProfileDetailScreen(profile: profile);
               });
+            case '/forum':
+              final flags = Provider.of<FeatureFlags>(context, listen: false);
+              if (!flags.forumEnabled) {
+                return MaterialPageRoute(
+                  builder: (_) => const ErrorScreen(
+                    message: 'Dieses Feature ist aktuell deaktiviert.',
+                  ),
+                  settings: settings,
+                );
+              }
+              return guard(
+                settings,
+                (_) => const FeaturePlaceholderScreen(
+                  title: 'Forum',
+                  message:
+                      'Hier entsteht das Community-Forum. Die Inhalte folgen in einer späteren Version.',
+                ),
+              );
+            case '/achievements':
+              final flags = Provider.of<FeatureFlags>(context, listen: false);
+              if (!flags.achievementsEnabled) {
+                return MaterialPageRoute(
+                  builder: (_) => const ErrorScreen(
+                    message: 'Dieses Feature ist aktuell deaktiviert.',
+                  ),
+                  settings: settings,
+                );
+              }
+              return guard(
+                settings,
+                (_) => const FeaturePlaceholderScreen(
+                  title: 'Erfolge',
+                  message:
+                      'Deine Erfolge erscheinen hier, sobald das Feature freigeschaltet ist.',
+                ),
+              );
             default:
               return MaterialPageRoute(
                 builder: (_) => const ErrorScreen(

--- a/lib/services/error_handler.dart
+++ b/lib/services/error_handler.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Provides shared error handling utilities so that UI widgets can
+/// consistently translate backend errors into user-friendly messages.
+class ErrorHandler {
+  const ErrorHandler._();
+
+  /// Maps [error] to a localized human-readable message. German is used by
+  /// default and can be toggled via [isGerman]. When no specific mapping is
+  /// found, [fallback] (if provided) or a generic string is returned.
+  static String messageFor(
+    Object error, {
+    bool isGerman = true,
+    String? fallback,
+  }) {
+    if (error is FirebaseAuthException) {
+      return _firebaseAuthMessage(error, isGerman, fallback);
+    }
+
+    if (error is FirebaseException) {
+      return _firebaseMessage(error, isGerman, fallback);
+    }
+
+    if (error is PlatformException) {
+      if (_isNetworkErrorCode(error.code)) {
+        return _offlineMessage(isGerman);
+      }
+      return error.message ??
+          fallback ??
+          _defaultMessage(isGerman);
+    }
+
+    if (error is SocketException) {
+      return _offlineMessage(isGerman);
+    }
+
+    if (error is TimeoutException) {
+      return isGerman
+          ? 'Die Anfrage hat zu lange gedauert. Bitte die Verbindung prüfen.'
+          : 'The request timed out. Please check your connection.';
+    }
+
+    if (error is FormatException) {
+      return isGerman
+          ? 'Unerwartetes Datenformat. Bitte später erneut versuchen.'
+          : 'Unexpected data format. Please try again later.';
+    }
+
+    return fallback ?? _defaultMessage(isGerman);
+  }
+
+  /// Shows a red floating [SnackBar] with [message] on the nearest
+  /// [ScaffoldMessenger]. Existing snack bars are cleared first to avoid
+  /// stacking duplicate errors.
+  static void showErrorSnack(BuildContext context, String message) {
+    if (message.isEmpty) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    messenger.clearSnackBars();
+    messenger.showSnackBar(
+      SnackBar(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: Theme.of(context).colorScheme.error,
+        content: Text(
+          message,
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+
+  /// Convenience helper: determines the locale from [context], derives the
+  /// message for [error] and displays it via [showErrorSnack].
+  static void showError(BuildContext context, Object error, {String? fallback}) {
+    final locale = Localizations.maybeLocaleOf(context);
+    final isGerman = locale?.languageCode.toLowerCase() == 'de';
+    final message = messageFor(
+      error,
+      isGerman: isGerman,
+      fallback: fallback,
+    );
+    showErrorSnack(context, message);
+  }
+
+  static String _firebaseAuthMessage(
+    FirebaseAuthException exception,
+    bool isGerman,
+    String? fallback,
+  ) {
+    switch (exception.code) {
+      case 'user-not-found':
+      case 'wrong-password':
+      case 'invalid-credential':
+      case 'invalid-email':
+        return isGerman
+            ? 'E-Mail oder Passwort ist ungültig.'
+            : 'Email or password is invalid.';
+      case 'user-disabled':
+        return isGerman
+            ? 'Dieses Konto wurde deaktiviert.'
+            : 'This account has been disabled.';
+      case 'email-already-in-use':
+        return isGerman
+            ? 'Diese E-Mail-Adresse wird bereits verwendet.'
+            : 'This email address is already in use.';
+      case 'weak-password':
+        return isGerman
+            ? 'Das Passwort ist zu schwach.'
+            : 'The password is too weak.';
+      case 'too-many-requests':
+        return isGerman
+            ? 'Zu viele Anmeldeversuche. Bitte später erneut versuchen.'
+            : 'Too many attempts. Please try again later.';
+      case 'network-request-failed':
+        return _offlineMessage(isGerman);
+      case 'operation-not-allowed':
+        return isGerman
+            ? 'Diese Anmeldung ist deaktiviert. Bitte Support kontaktieren.'
+            : 'This sign-in method is disabled. Please contact support.';
+    }
+
+    return fallback ?? _defaultMessage(isGerman);
+  }
+
+  static String _firebaseMessage(
+    FirebaseException exception,
+    bool isGerman,
+    String? fallback,
+  ) {
+    switch (exception.code) {
+      case 'permission-denied':
+      case 'unauthenticated':
+        return isGerman
+            ? 'Zugriff verweigert. Bitte erneut anmelden.'
+            : 'Permission denied. Please sign in again.';
+      case 'unavailable':
+      case 'network-request-failed':
+      case 'network-error':
+        return _offlineMessage(isGerman);
+      case 'cancelled':
+      case 'aborted':
+        return isGerman
+            ? 'Der Vorgang wurde abgebrochen. Bitte erneut versuchen.'
+            : 'The operation was cancelled. Please try again.';
+      case 'deadline-exceeded':
+        return isGerman
+            ? 'Die Anfrage hat zu lange gedauert. Bitte erneut versuchen.'
+            : 'The request timed out. Please try again.';
+      case 'not-found':
+        return isGerman
+            ? 'Der angeforderte Eintrag wurde nicht gefunden.'
+            : 'The requested item was not found.';
+      case 'already-exists':
+        return isGerman
+            ? 'Der Eintrag existiert bereits.'
+            : 'The entry already exists.';
+      case 'resource-exhausted':
+        return isGerman
+            ? 'Kontingent erschöpft. Bitte später erneut probieren.'
+            : 'Quota exceeded. Please try again later.';
+      case 'failed-precondition':
+        return isGerman
+            ? 'Eine Voraussetzung wurde nicht erfüllt.'
+            : 'A precondition was not met.';
+    }
+
+    return fallback ?? _defaultMessage(isGerman);
+  }
+
+  static bool _isNetworkErrorCode(String code) {
+    switch (code) {
+      case 'network_error':
+      case 'network-request-failed':
+      case 'internet_disconnected':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  static String _offlineMessage(bool isGerman) {
+    return isGerman
+        ? 'Keine Internetverbindung. Änderungen werden synchronisiert, sobald du wieder online bist.'
+        : 'No internet connection. Changes will sync once you are back online.';
+  }
+
+  static String _defaultMessage(bool isGerman) {
+    return isGerman
+        ? 'Etwas ist schiefgelaufen. Bitte später erneut versuchen.'
+        : 'Something went wrong. Please try again later.';
+  }
+}

--- a/lib/services/feature_flags.dart
+++ b/lib/services/feature_flags.dart
@@ -1,0 +1,35 @@
+/// Feature flag configuration controlling access to optional app areas.
+///
+/// The flags default to `false` because they will later be hydrated from a
+/// remote configuration source (see T5.x). Until then the application can
+/// instantiate a constant set locally and provide it via a [Provider].
+class FeatureFlags {
+  final bool parentsTrackEnabled;
+  final bool trainerTrackEnabled;
+  final bool forumEnabled;
+  final bool achievementsEnabled;
+
+  const FeatureFlags({
+    this.parentsTrackEnabled = false,
+    this.trainerTrackEnabled = false,
+    this.forumEnabled = false,
+    this.achievementsEnabled = false,
+  });
+
+  FeatureFlags copyWith({
+    bool? parentsTrackEnabled,
+    bool? trainerTrackEnabled,
+    bool? forumEnabled,
+    bool? achievementsEnabled,
+  }) {
+    return FeatureFlags(
+      parentsTrackEnabled:
+          parentsTrackEnabled ?? this.parentsTrackEnabled,
+      trainerTrackEnabled:
+          trainerTrackEnabled ?? this.trainerTrackEnabled,
+      forumEnabled: forumEnabled ?? this.forumEnabled,
+      achievementsEnabled:
+          achievementsEnabled ?? this.achievementsEnabled,
+    );
+  }
+}

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -1,12 +1,98 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'package:free_base/constants/app_strings.dart';
 import 'package:free_base/features/training/screens/phase_selection_screen.dart';
+import 'package:free_base/services/feature_flags.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final featureFlags = context.watch<FeatureFlags>();
+
+    final items = <Widget>[
+      ListTile(
+        leading: const Icon(Icons.dashboard),
+        title: const Text('Dashboard'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.pushNamed(context, '/dashboard');
+        },
+      ),
+      ListTile(
+        leading: const Icon(Icons.fitness_center),
+        title: const Text('Training'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.pushNamed(context, '/training');
+        },
+      ),
+      ListTile(
+        leading: const Icon(Icons.calendar_today),
+        title: const Text('Kalender'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.pushNamed(context, '/calendar');
+        },
+      ),
+      ListTile(
+        leading: const Icon(Icons.settings),
+        title: const Text('Einstellungen'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.pushNamed(context, '/settings');
+        },
+      ),
+      ListTile(
+        leading: const Icon(Icons.quiz),
+        title: const Text('Fragebogen'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.pushNamed(context, '/questionnaire');
+        },
+      ),
+      ListTile(
+        leading: const Icon(Icons.person),
+        title: const Text('Reflexprofile'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.pushNamed(context, '/reflexe-profil');
+        },
+      ),
+      if (featureFlags.forumEnabled)
+        ListTile(
+          leading: const Icon(Icons.forum),
+          title: const Text('Forum (Beta)'),
+          onTap: () {
+            Navigator.pop(context);
+            Navigator.pushNamed(context, '/forum');
+          },
+        ),
+      if (featureFlags.achievementsEnabled)
+        ListTile(
+          leading: const Icon(Icons.emoji_events),
+          title: const Text('Erfolge'),
+          onTap: () {
+            Navigator.pop(context);
+            Navigator.pushNamed(context, '/achievements');
+          },
+        ),
+      ListTile(
+        leading: const Icon(Icons.playlist_play),
+        title: const Text('Phase auswählen'),
+        onTap: () {
+          Navigator.pop(context);
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => const PhaseSelectionScreen(),
+            ),
+          );
+        },
+      ),
+    ];
+
     return Drawer(
       child: SafeArea(
         child: ListView(
@@ -34,66 +120,7 @@ class AppDrawer extends StatelessWidget {
                 ],
               ),
             ),
-            ListTile(
-              leading: const Icon(Icons.dashboard),
-              title: const Text('Dashboard'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/dashboard');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.fitness_center),
-              title: const Text('Training'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/training');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.calendar_today),
-              title: const Text('Kalender'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/calendar');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.settings),
-              title: const Text('Einstellungen'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/settings');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.quiz),
-              title: const Text('Fragebogen'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/questionnaire');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.person),
-              title: const Text('Reflexprofile'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.pushNamed(context, '/reflexe-profil');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.playlist_play),
-              title: const Text('Phase ausw\u00e4hlen'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const PhaseSelectionScreen(),
-                  ),
-                );
-              },
-            ),
+            ...items,
           ],
         ),
       ),

--- a/lib/widgets/connectivity_banner.dart
+++ b/lib/widgets/connectivity_banner.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+
+/// Displays a lightweight banner whenever the device is offline.
+///
+/// The widget listens to connectivity updates and can optionally receive
+/// custom [connectivityStream] and [checkConnectivity] callbacks which makes it
+/// easy to mock in tests.
+class ConnectivityBanner extends StatefulWidget {
+  final Stream<ConnectivityResult>? connectivityStream;
+  final Future<ConnectivityResult> Function()? checkConnectivity;
+
+  const ConnectivityBanner({
+    super.key,
+    this.connectivityStream,
+    this.checkConnectivity,
+  });
+
+  @override
+  State<ConnectivityBanner> createState() => _ConnectivityBannerState();
+}
+
+class _ConnectivityBannerState extends State<ConnectivityBanner> {
+  ConnectivityResult? _status;
+  StreamSubscription<ConnectivityResult>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = (widget.connectivityStream ??
+            Connectivity().onConnectivityChanged)
+        .listen((result) {
+      if (!mounted) return;
+      setState(() => _status = result);
+    });
+    _initCurrentStatus();
+  }
+
+  Future<void> _initCurrentStatus() async {
+    try {
+      final checker = widget.checkConnectivity ??
+          () => Connectivity().checkConnectivity();
+      final result = await checker();
+      if (!mounted) return;
+      setState(() => _status = result);
+    } catch (_) {
+      // If the connectivity plugin is unavailable we simply keep the banner
+      // hidden. This can happen in widget tests without platform channels.
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final offline = _status == ConnectivityResult.none;
+    if (!offline) {
+      return const SizedBox.shrink();
+    }
+
+    final locale = Localizations.maybeLocaleOf(context);
+    final isGerman = locale?.languageCode.toLowerCase() == 'de';
+    final message = isGerman
+        ? 'Keine Internetverbindung. Wir synchronisieren automatisch, sobald du wieder online bist.'
+        : 'You are offline. We will sync automatically once you are back online.';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: Colors.orange.shade700,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.wifi_off, color: Colors.white),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/golden_day_test.dart
+++ b/test/golden_day_test.dart
@@ -5,13 +5,19 @@ void main() {
   final service = GoldenDayService();
 
   group('GoldenDayService', () {
+    test('zero sessions extend the phase significantly', () {
+      final start = DateTime(2024, 1, 1);
+      final result = service.calculateGoldenDay(start, {0: 0});
+      expect(result, start.add(const Duration(days: 40)));
+    });
+
     test('no weeks -> first golden day after 6 days', () {
       final start = DateTime(2024, 1, 1); // monday
       final result = service.calculateGoldenDay(start, {});
       expect(result, start.add(const Duration(days: 6)));
     });
 
-    test('complete week keeps weekday', () {
+    test('six sessions keep the baseline schedule', () {
       final start = DateTime(2024, 1, 1);
       final result = service.calculateGoldenDay(start, {0: 6});
       expect(result, start.add(const Duration(days: 13)));
@@ -23,7 +29,7 @@ void main() {
       expect(result, start.add(const Duration(days: 14)));
     });
 
-    test('extra sessions shift earlier', () {
+    test('more than six sessions shift earlier', () {
       final start = DateTime(2024, 1, 1);
       final result = service.calculateGoldenDay(start, {0: 7});
       expect(result, start.add(const Duration(days: 12)));

--- a/test/login_dashboard_flow_test.dart
+++ b/test/login_dashboard_flow_test.dart
@@ -1,0 +1,85 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/features/onboarding/screens/login_screen.dart';
+import 'package:free_base/features/onboarding/services/auth_service.dart';
+
+class MockAuthService extends Mock implements AuthService {}
+
+class FakeUserCredential extends Fake implements UserCredential {}
+
+class _FakeSelectRoleScreen extends StatefulWidget {
+  const _FakeSelectRoleScreen();
+
+  @override
+  State<_FakeSelectRoleScreen> createState() => _FakeSelectRoleScreenState();
+}
+
+class _FakeSelectRoleScreenState extends State<_FakeSelectRoleScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      if (!mounted) return;
+      Navigator.pushReplacementNamed(context, '/dashboard');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Role Selection Placeholder')),
+    );
+  }
+}
+
+class _FakeDashboardScreen extends StatelessWidget {
+  const _FakeDashboardScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Dashboard Placeholder')),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('login success navigates through role selection to dashboard',
+      (tester) async {
+    final mockAuth = MockAuthService();
+    when(mockAuth.signInWithEmail(any, any))
+        .thenAnswer((_) async => FakeUserCredential());
+
+    await tester.pumpWidget(
+      Provider<AuthService>.value(
+        value: mockAuth,
+        child: MaterialApp(
+          initialRoute: '/login',
+          routes: {
+            '/login': (_) => const LoginScreen(),
+            '/select-role': (_) => const _FakeSelectRoleScreen(),
+            '/dashboard': (_) => const _FakeDashboardScreen(),
+          },
+        ),
+      ),
+    );
+
+    await tester.enterText(
+        find.byType(TextField).at(0), 'test@example.com');
+    await tester.enterText(find.byType(TextField).at(1), 'password123');
+    await tester.tap(find.text('Anmelden'));
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard Placeholder'), findsOneWidget);
+    verify(mockAuth.signInWithEmail('test@example.com', 'password123'))
+        .called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce a feature flag service, wire it into the main provider tree, and hide or expose drawer navigation and routes with placeholder screens based on the configured toggles
- centralise user-facing error handling via a reusable ErrorHandler helper and add an offline connectivity banner to keep training flows resilient without duplicate snackbars
- expand automated coverage with a widget test for the login-to-dashboard flow and GoldenDayService edge cases

## Testing
- `flutter test` *(fails: flutter CLI is unavailable in the execution environment)*
- `npm test` *(fails: jest is unavailable because npm install cannot reach the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d16bdb9060832d8482ec4182084068