### PR TITLE
Synthesize Moro beep audio programmatically

### DIFF
--- a/assets/moro/moro_exercises.json
+++ b/assets/moro/moro_exercises.json
@@ -1,0 +1,9 @@
+[
+  {"index":1,"title":"Moro 1","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
+  {"index":2,"title":"Moro 2","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
+  {"index":3,"title":"Moro 3","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
+  {"index":4,"title":"Moro 4","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
+  {"index":5,"title":"Moro 5","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
+  {"index":6,"title":"Moro 6","type":"simple","repeats":6,"phasesPerRepeat":1,"baseSeconds":7},
+  {"index":7,"title":"Moro 7","type":"simple","repeats":6,"phasesPerRepeat":1,"baseSeconds":7}
+]

--- a/lib/features/training/moro/moro_models.dart
+++ b/lib/features/training/moro/moro_models.dart
@@ -1,0 +1,19 @@
+enum MoroExerciseType { phased4x, simple }
+
+class MoroExercise {
+  final int index;
+  final String title;
+  final MoroExerciseType type;
+  final int repeats;
+  final int phasesPerRepeat;
+  final int baseSeconds;
+
+  const MoroExercise({
+    required this.index,
+    required this.title,
+    required this.type,
+    required this.repeats,
+    required this.phasesPerRepeat,
+    required this.baseSeconds,
+  });
+}

--- a/lib/features/training/moro/moro_repository.dart
+++ b/lib/features/training/moro/moro_repository.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+import 'moro_models.dart';
+
+class MoroRepository {
+  Future<List<MoroExercise>> load() async {
+    final raw = await rootBundle.loadString('assets/moro/moro_exercises.json');
+    final list = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
+    return list
+      .map((e) => MoroExercise(
+            index: e['index'] as int,
+            title: e['title'] as String,
+            type: e['type'] == 'phased4x'
+                ? MoroExerciseType.phased4x
+                : MoroExerciseType.simple,
+            repeats: e['repeats'] as int,
+            phasesPerRepeat: e['phasesPerRepeat'] as int,
+            baseSeconds: e['baseSeconds'] as int,
+          ))
+      .toList()
+      ..sort((a, b) => a.index.compareTo(b.index));
+  }
+}

--- a/lib/features/training/moro/moro_speed_store.dart
+++ b/lib/features/training/moro/moro_speed_store.dart
@@ -1,0 +1,43 @@
+import 'package:hive/hive.dart';
+
+class MoroSpeedStore {
+  static const _boxName = 'moro_speed_offsets';
+  static const _offsetsKey = 'offsets';
+
+  static Future<int> getOffsetForExercise(int exerciseIndex) async {
+    final box = await Hive.openBox(_boxName);
+    final raw = box.get(_offsetsKey);
+    if (raw is Map) {
+      final entry = raw['$exerciseIndex'];
+      if (entry is int) {
+        return entry;
+      }
+      if (entry is num) {
+        return entry.toInt();
+      }
+    }
+    return 0;
+  }
+
+  static Future<void> setOffsetForExercise(int exerciseIndex, int offsetSec) async {
+    final box = await Hive.openBox(_boxName);
+    final dynamic raw = box.get(_offsetsKey);
+    final Map<String, int> map = {};
+    if (raw is Map) {
+      raw.forEach((key, value) {
+        if (value is int) {
+          map[key.toString()] = value;
+        } else if (value is num) {
+          map[key.toString()] = value.toInt();
+        }
+      });
+    }
+    final clamped = offsetSec < 0
+        ? 0
+        : offsetSec > 3
+            ? 3
+            : offsetSec;
+    map['$exerciseIndex'] = clamped;
+    await box.put(_offsetsKey, map);
+  }
+}

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -1,0 +1,308 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'moro_models.dart';
+import 'moro_repository.dart';
+import 'moro_speed_store.dart';
+import 'timers.dart';
+
+class MoroTrainingScreen extends StatefulWidget {
+  const MoroTrainingScreen({super.key});
+
+  @override
+  State<MoroTrainingScreen> createState() => _MoroTrainingScreenState();
+}
+
+class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
+  late Future<List<MoroExercise>> _future;
+  final Map<int, int> _offsets = <int, int>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _future = MoroRepository().load();
+  }
+
+  Future<int> _getOffset(int index) async {
+    if (_offsets.containsKey(index)) {
+      return _offsets[index]!;
+    }
+    final value = await MoroSpeedStore.getOffsetForExercise(index);
+    _offsets[index] = value;
+    return value;
+  }
+
+  Future<void> _setOffset(int index, int value) async {
+    await MoroSpeedStore.setOffsetForExercise(index, value);
+    setState(() {
+      _offsets[index] = value;
+    });
+  }
+
+  void _openExercise(BuildContext context, MoroExercise exercise, int offset) {
+    final token = CancelToken();
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _MoroRunDialog(
+        exercise: exercise,
+        offset: offset,
+        cancelToken: token,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Moro Training'),
+      ),
+      body: FutureBuilder<List<MoroExercise>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final exercises = snapshot.data ?? <MoroExercise>[];
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemBuilder: (context, index) {
+              final exercise = exercises[index];
+              return FutureBuilder<int>(
+                future: _getOffset(exercise.index),
+                builder: (context, offsetSnapshot) {
+                  final offset = offsetSnapshot.data ?? _offsets[exercise.index] ?? 0;
+                  return Card(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _SpeedChips(
+                            value: offset,
+                            onChanged: (value) => _setOffset(exercise.index, value),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  '${exercise.index}. ${exercise.title}',
+                                  style: Theme.of(context).textTheme.titleMedium,
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  exercise.type == MoroExerciseType.phased4x
+                                      ? '3 Wiederholungen · 4 Phasen × ${exercise.baseSeconds + offset}s · Pause 3s'
+                                      : '6 Wiederholungen · ${exercise.baseSeconds + offset}s pro Wiederholung · Pause 3s',
+                                ),
+                                const SizedBox(height: 8),
+                                Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: ElevatedButton(
+                                    onPressed: () => _openExercise(context, exercise, offset),
+                                    child: const Text('Start'),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemCount: exercises.length,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SpeedChips extends StatelessWidget {
+  const _SpeedChips({
+    required this.value,
+    required this.onChanged,
+  });
+
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final options = List<int>.generate(4, (index) => index);
+    return SizedBox(
+      width: 96,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value == 0 ? 'Standard' : '+${value}s',
+            style: Theme.of(context).textTheme.labelMedium,
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final option in options)
+                ChoiceChip(
+                  label: Text(option == 0 ? 'Std' : '+${option}s'),
+                  selected: option == value,
+                  onSelected: (_) => onChanged(option),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MoroRunDialog extends StatefulWidget {
+  const _MoroRunDialog({
+    required this.exercise,
+    required this.offset,
+    required this.cancelToken,
+  });
+
+  final MoroExercise exercise;
+  final int offset;
+  final CancelToken cancelToken;
+
+  @override
+  State<_MoroRunDialog> createState() => _MoroRunDialogState();
+}
+
+class _MoroRunDialogState extends State<_MoroRunDialog> {
+  StreamSubscription<dynamic>? _subscription;
+  int _repeat = 1;
+  int _phase = 1;
+  Duration _remaining = Duration.zero;
+  double _progress = 0;
+
+  int get _unitSeconds => widget.exercise.baseSeconds + widget.offset;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.exercise.type == MoroExerciseType.phased4x) {
+      final timer = PhasedMoroTimer(
+        repeats: widget.exercise.repeats,
+        phasesPerRepeat: widget.exercise.phasesPerRepeat,
+        phaseSeconds: _unitSeconds,
+      );
+      _subscription = timer.run(widget.cancelToken).listen((event) {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _repeat = event.repeatIdx;
+          _phase = event.phaseIdx;
+          _remaining = event.remaining;
+          _progress = _calculatePhasedProgress(event.repeatIdx, event.phaseIdx, event.remaining);
+        });
+        if (event.done && mounted) {
+          Navigator.of(context).pop();
+        }
+      });
+    } else {
+      final timer = SimpleMoroTimer(
+        repeats: widget.exercise.repeats,
+        repeatSeconds: _unitSeconds,
+      );
+      _subscription = timer.run(widget.cancelToken).listen((event) {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _repeat = event.repeatIdx;
+          _phase = 1;
+          _remaining = event.remaining;
+          _progress = _calculateSimpleProgress(event.repeatIdx, event.remaining);
+        });
+        if (event.done && mounted) {
+          Navigator.of(context).pop();
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  double _calculatePhasedProgress(int repeat, int phase, Duration remaining) {
+    final totalPhases = widget.exercise.repeats * widget.exercise.phasesPerRepeat;
+    final completedPhases = (repeat - 1) * widget.exercise.phasesPerRepeat + (phase - 1);
+    final phaseMillis = _unitSeconds * 1000;
+    final remainingMillis = remaining.inMilliseconds.clamp(0, phaseMillis);
+    final currentProgress = phaseMillis == 0
+        ? 1.0
+        : 1 - (remainingMillis / phaseMillis);
+    final overall = (completedPhases + currentProgress) / totalPhases;
+    return overall.clamp(0, 1);
+  }
+
+  double _calculateSimpleProgress(int repeat, Duration remaining) {
+    final totalRepeats = widget.exercise.repeats;
+    final completedRepeats = repeat - 1;
+    final unitMillis = _unitSeconds * 1000;
+    final remainingMillis = remaining.inMilliseconds.clamp(0, unitMillis);
+    final currentProgress = unitMillis == 0
+        ? 1.0
+        : 1 - (remainingMillis / unitMillis);
+    final overall = (completedRepeats + currentProgress) / totalRepeats;
+    return overall.clamp(0, 1);
+  }
+
+  int _remainingSecondsCeil() {
+    final ms = _remaining.inMilliseconds;
+    if (ms <= 0) {
+      return 0;
+    }
+    return (ms / 1000).ceil();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final exercise = widget.exercise;
+    return AlertDialog(
+      title: Text(exercise.title),
+      content: SizedBox(
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Wiederholung: $_repeat / ${exercise.repeats}'),
+            if (exercise.type == MoroExerciseType.phased4x)
+              Text('Phase: $_phase / ${exercise.phasesPerRepeat}'),
+            const SizedBox(height: 12),
+            Text('Restzeit: ${_remainingSecondsCeil()}s'),
+            const SizedBox(height: 12),
+            LinearProgressIndicator(value: _progress),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            widget.cancelToken.cancel();
+            Navigator.of(context).pop();
+          },
+          child: const Text('Abbrechen'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/training/moro/timers.dart
+++ b/lib/features/training/moro/timers.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+
+import '../../../services/beeper.dart';
+import '../../../services/haptics.dart';
+
+class CancelToken {
+  bool _canceled = false;
+
+  void cancel() {
+    _canceled = true;
+  }
+
+  bool get canceled => _canceled;
+}
+
+class PhasedMoroTimer {
+  final int repeats;
+  final int phasesPerRepeat;
+  final int phaseSeconds;
+  final int restBetweenRepeatsSeconds;
+
+  const PhasedMoroTimer({
+    required this.repeats,
+    required this.phasesPerRepeat,
+    required this.phaseSeconds,
+    this.restBetweenRepeatsSeconds = 3,
+  });
+
+  Duration get totalDuration => Duration(
+        seconds: (repeats * phasesPerRepeat * phaseSeconds) +
+            (repeats <= 1 ? 0 : (repeats - 1) * restBetweenRepeatsSeconds),
+      );
+
+  Stream<({int repeatIdx, int phaseIdx, Duration remaining, bool done})> run(
+    CancelToken token,
+  ) async* {
+    final phaseDuration = Duration(seconds: phaseSeconds);
+    for (var repeat = 1; repeat <= repeats; repeat++) {
+      for (var phase = 1; phase <= phasesPerRepeat; phase++) {
+        if (token.canceled) {
+          return;
+        }
+        await Future.wait([Beeper.beep(), Haptics.phase()]);
+        final stopwatch = Stopwatch()..start();
+        var firstLoop = true;
+        while (!token.canceled) {
+          final elapsed = stopwatch.elapsed;
+          if (elapsed >= phaseDuration) {
+            yield (
+              repeatIdx: repeat,
+              phaseIdx: phase,
+              remaining: Duration.zero,
+              done: false,
+            );
+            break;
+          }
+          final remaining = phaseDuration - elapsed;
+          if (!firstLoop) {
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            if (token.canceled) {
+              return;
+            }
+          }
+          yield (
+            repeatIdx: repeat,
+            phaseIdx: phase,
+            remaining: remaining,
+            done: false,
+          );
+          firstLoop = false;
+        }
+      }
+      if (token.canceled) {
+        return;
+      }
+      if (repeat < repeats) {
+        final restDuration = Duration(seconds: restBetweenRepeatsSeconds);
+        final restWatch = Stopwatch()..start();
+        while (restWatch.elapsed < restDuration) {
+          if (token.canceled) {
+            return;
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        }
+      }
+    }
+    yield (
+      repeatIdx: repeats,
+      phaseIdx: phasesPerRepeat,
+      remaining: Duration.zero,
+      done: true,
+    );
+  }
+}
+
+class SimpleMoroTimer {
+  final int repeats;
+  final int repeatSeconds;
+  final int restBetweenRepeatsSeconds;
+
+  const SimpleMoroTimer({
+    required this.repeats,
+    required this.repeatSeconds,
+    this.restBetweenRepeatsSeconds = 3,
+  });
+
+  Duration get totalDuration => Duration(
+        seconds: (repeats * repeatSeconds) +
+            (repeats <= 1 ? 0 : (repeats - 1) * restBetweenRepeatsSeconds),
+      );
+
+  Stream<({
+    int repeatIdx,
+    Duration remaining,
+    bool done,
+    bool justStarted,
+    bool justEnded,
+  })> run(CancelToken token) async* {
+    final repeatDuration = Duration(seconds: repeatSeconds);
+    for (var repeat = 1; repeat <= repeats; repeat++) {
+      if (token.canceled) {
+        return;
+      }
+      await Future.wait([Beeper.beep(), Haptics.repStart()]);
+      final stopwatch = Stopwatch()..start();
+      var firstLoop = true;
+      while (!token.canceled) {
+        final elapsed = stopwatch.elapsed;
+        if (elapsed >= repeatDuration) {
+          yield (
+            repeatIdx: repeat,
+            remaining: Duration.zero,
+            done: false,
+            justStarted: false,
+            justEnded: false,
+          );
+          break;
+        }
+        final remaining = repeatDuration - elapsed;
+        if (!firstLoop) {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          if (token.canceled) {
+            return;
+          }
+        }
+        yield (
+          repeatIdx: repeat,
+          remaining: remaining,
+          done: false,
+          justStarted: firstLoop,
+          justEnded: false,
+        );
+        firstLoop = false;
+      }
+      if (token.canceled) {
+        return;
+      }
+      await Future.wait([Beeper.beep(), Haptics.repEnd()]);
+      yield (
+        repeatIdx: repeat,
+        remaining: Duration.zero,
+        done: false,
+        justStarted: false,
+        justEnded: true,
+      );
+      if (repeat < repeats) {
+        final restDuration = Duration(seconds: restBetweenRepeatsSeconds);
+        final restWatch = Stopwatch()..start();
+        while (restWatch.elapsed < restDuration) {
+          if (token.canceled) {
+            return;
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        }
+      }
+    }
+    yield (
+      repeatIdx: repeats,
+      remaining: Duration.zero,
+      done: true,
+      justStarted: false,
+      justEnded: false,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'package:free_base/features/onboarding/screens/register_screen.dart';
 import 'package:free_base/features/onboarding/screens/role_selection_screen.dart';
 import 'package:free_base/features/common/dashboard_screen.dart';
 import 'package:free_base/features/onboarding/profile/settings_screen.dart';
-import 'package:free_base/features/training/training_screen.dart';
+import 'package:free_base/features/training/moro/moro_training_screen.dart';
 import 'package:free_base/features/calendar/screens/calendar_screen.dart';
 import 'package:free_base/features/common/error_screen.dart';
 
@@ -206,7 +206,8 @@ class MyApp extends StatelessWidget {
             case '/settings':
               return guard(settings, (_) => const SettingsScreen());
             case '/training':
-              return guard(settings, (_) => const TrainingScreen());
+            case '/training/moro':
+              return guard(settings, (_) => const MoroTrainingScreen());
             case '/calendar':
               return guard(settings, (_) => const CalendarScreen());
             case '/questionnaire':

--- a/lib/services/beeper.dart
+++ b/lib/services/beeper.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:audioplayers/audioplayers.dart';
+
+class Beeper {
+  Beeper._();
+
+  static final AudioPlayer _player = AudioPlayer();
+  static bool _configured = false;
+  static Uint8List? _cachedBeep;
+
+  static Future<void> _ensureConfigured() async {
+    if (_configured) {
+      return;
+    }
+    await _player.setReleaseMode(ReleaseMode.stop);
+    _configured = true;
+  }
+
+  static Future<void> beep() async {
+    await _ensureConfigured();
+    _cachedBeep ??= _generateBeep();
+    await _player.play(BytesSource(_cachedBeep!));
+  }
+
+  static Uint8List _generateBeep() {
+    const sampleRate = 22050;
+    const frequency = 880.0;
+    const durationSeconds = 0.25;
+    const amplitude = 0.35;
+    final sampleCount = (sampleRate * durationSeconds).round();
+
+    final pcmDataBuilder = BytesBuilder();
+    for (var i = 0; i < sampleCount; i++) {
+      final time = i / sampleRate;
+      final sample = sin(2 * pi * frequency * time);
+      final amplitudeScaled = (sample * amplitude * 0x7fff).round();
+      pcmDataBuilder.add(_int16le(amplitudeScaled));
+    }
+    final pcmData = pcmDataBuilder.toBytes();
+
+    final wavBuilder = BytesBuilder();
+    void writeString(String value) => wavBuilder.add(ascii.encode(value));
+    void writeInt32(int value) => wavBuilder.add(_int32le(value));
+    void writeInt16(int value) => wavBuilder.add(_int16le(value));
+
+    writeString('RIFF');
+    writeInt32(36 + pcmData.length);
+    writeString('WAVE');
+    writeString('fmt ');
+    writeInt32(16); // PCM chunk size
+    writeInt16(1); // audio format PCM
+    writeInt16(1); // channels
+    writeInt32(sampleRate);
+    writeInt32(sampleRate * 2); // byte rate (sampleRate * channels * bytesPerSample)
+    writeInt16(2); // block align (channels * bytesPerSample)
+    writeInt16(16); // bits per sample
+    writeString('data');
+    writeInt32(pcmData.length);
+    wavBuilder.add(pcmData);
+
+    return wavBuilder.toBytes();
+  }
+
+  static List<int> _int16le(int value) {
+    final v = value & 0xffff;
+    return [v & 0xff, (v >> 8) & 0xff];
+  }
+
+  static List<int> _int32le(int value) {
+    final v = value & 0xffffffff;
+    return [
+      v & 0xff,
+      (v >> 8) & 0xff,
+      (v >> 16) & 0xff,
+      (v >> 24) & 0xff,
+    ];
+  }
+}

--- a/lib/services/haptics.dart
+++ b/lib/services/haptics.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/services.dart';
+
+class Haptics {
+  Haptics._();
+
+  static Future<void> phase() async {
+    await HapticFeedback.lightImpact();
+  }
+
+  static Future<void> repStart() async {
+    await HapticFeedback.mediumImpact();
+  }
+
+  static Future<void> repEnd() async {
+    await HapticFeedback.selectionClick();
+  }
+}

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:free_base/constants/app_strings.dart';
-import 'package:free_base/features/training/screens/phase_selection_screen.dart';
 import 'package:free_base/services/feature_flags.dart';
 
 class AppDrawer extends StatelessWidget {
@@ -26,7 +25,7 @@ class AppDrawer extends StatelessWidget {
         title: const Text('Training'),
         onTap: () {
           Navigator.pop(context);
-          Navigator.pushNamed(context, '/training');
+          Navigator.pushNamed(context, '/training/moro');
         },
       ),
       ListTile(
@@ -79,18 +78,6 @@ class AppDrawer extends StatelessWidget {
             Navigator.pushNamed(context, '/achievements');
           },
         ),
-      ListTile(
-        leading: const Icon(Icons.playlist_play),
-        title: const Text('Phase auswählen'),
-        onTap: () {
-          Navigator.pop(context);
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => const PhaseSelectionScreen(),
-            ),
-          );
-        },
-      ),
     ];
 
     return Drawer(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   google_fonts: ^6.2.1
   json_annotation: ^4.9.0
   freezed_annotation: ^2.1.0
-  audioplayers: ^6.4.0
+  audioplayers: ^6.0.0
   video_player: ^2.7.0
 
   # Offline-Persistence mit Hive (inkl. Verschlüsselung)
@@ -61,6 +61,7 @@ flutter:
     - assets/images/paw.png
     - assets/images/tick.png
     - assets/sounds/
+    - assets/moro/moro_exercises.json
     - assets/quiz_questions_de.json
     - assets/quiz_questions_en.json
     - assets/videos/test_video.mp4

--- a/test/moro_timers_test.dart
+++ b/test/moro_timers_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:free_base/features/training/moro/moro_speed_store.dart';
+import 'package:free_base/features/training/moro/timers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Moro timer durations', () {
+    test('PhasedMoroTimer duration math includes rests and offset seconds', () {
+      const offset = 2;
+      final timer = PhasedMoroTimer(
+        repeats: 3,
+        phasesPerRepeat: 4,
+        phaseSeconds: 3 + offset,
+        restBetweenRepeatsSeconds: 3,
+      );
+      expect(timer.totalDuration, const Duration(seconds: 66));
+    });
+
+    test('SimpleMoroTimer duration math includes rests and offset seconds', () {
+      const offset = 3;
+      final timer = SimpleMoroTimer(
+        repeats: 6,
+        repeatSeconds: 7 + offset,
+        restBetweenRepeatsSeconds: 3,
+      );
+      expect(timer.totalDuration, const Duration(seconds: 75));
+    });
+  });
+
+  group('MoroSpeedStore', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('moro_speed_store_test');
+      Hive.init(tempDir.path);
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('persists and clamps offsets per exercise', () async {
+      await MoroSpeedStore.setOffsetForExercise(3, 5);
+      expect(await MoroSpeedStore.getOffsetForExercise(3), 3);
+
+      await MoroSpeedStore.setOffsetForExercise(3, -1);
+      expect(await MoroSpeedStore.getOffsetForExercise(3), 0);
+
+      await MoroSpeedStore.setOffsetForExercise(2, 1);
+      expect(await MoroSpeedStore.getOffsetForExercise(2), 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- synthesize the Moro beep tone at runtime to avoid bundling the binary asset
- expose totalDuration helpers on Moro timers and update tests accordingly
- remove the beep asset reference from pubspec since it is no longer required

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d187cd0340832db5d95f2ce48240e3