### PR TITLE
Use Moro training entry point and asset beep

### DIFF
--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -1,7 +1,6 @@
 // lib/features/common/dashboard_screen.dart
 
 import 'package:flutter/material.dart';
-import 'package:free_base/features/training/training_screen.dart';
 import 'package:free_base/features/calendar/screens/calendar_screen.dart';
 import 'package:free_base/widgets/app_drawer.dart';
 
@@ -23,10 +22,9 @@ class DashboardScreen extends StatelessWidget {
             const Text('Willkommen im Dashboard!'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const TrainingScreen()),
-              ),
+              onPressed: () {
+                Navigator.pushNamed(context, '/training/moro');
+              },
               child: const Text('Zum Training'),
             ),
             const SizedBox(height: 12),

--- a/lib/features/training/moro/moro_speed_store.dart
+++ b/lib/features/training/moro/moro_speed_store.dart
@@ -4,40 +4,35 @@ class MoroSpeedStore {
   static const _boxName = 'moro_speed_offsets';
   static const _offsetsKey = 'offsets';
 
-  static Future<int> getOffsetForExercise(int exerciseIndex) async {
-    final box = await Hive.openBox(_boxName);
+  static Future<Box<dynamic>> _openBox() => Hive.openBox<dynamic>(_boxName);
+
+  static int _sanitizeOffset(num value) => value.clamp(0, 3).toInt();
+
+  static Map<String, int> _readOffsets(Box<dynamic> box) {
     final raw = box.get(_offsetsKey);
     if (raw is Map) {
-      final entry = raw['$exerciseIndex'];
-      if (entry is int) {
-        return entry;
-      }
-      if (entry is num) {
-        return entry.toInt();
-      }
+      final result = <String, int>{};
+      raw.forEach((key, value) {
+        if (value is num) {
+          result[key.toString()] = _sanitizeOffset(value);
+        }
+      });
+      return result;
     }
-    return 0;
+    return <String, int>{};
+  }
+
+  static Future<int> getOffsetForExercise(int exerciseIndex) async {
+    final box = await _openBox();
+    final offsets = _readOffsets(box);
+    final value = offsets['$exerciseIndex'];
+    return value ?? 0;
   }
 
   static Future<void> setOffsetForExercise(int exerciseIndex, int offsetSec) async {
-    final box = await Hive.openBox(_boxName);
-    final dynamic raw = box.get(_offsetsKey);
-    final Map<String, int> map = {};
-    if (raw is Map) {
-      raw.forEach((key, value) {
-        if (value is int) {
-          map[key.toString()] = value;
-        } else if (value is num) {
-          map[key.toString()] = value.toInt();
-        }
-      });
-    }
-    final clamped = offsetSec < 0
-        ? 0
-        : offsetSec > 3
-            ? 3
-            : offsetSec;
-    map['$exerciseIndex'] = clamped;
-    await box.put(_offsetsKey, map);
+    final box = await _openBox();
+    final offsets = _readOffsets(box);
+    offsets['$exerciseIndex'] = _sanitizeOffset(offsetSec);
+    await box.put(_offsetsKey, offsets);
   }
 }

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -62,6 +62,14 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
       body: FutureBuilder<List<MoroExercise>>(
         future: _future,
         builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Text(
+                'Fehler beim Laden der Moro-Übungen',
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            );
+          }
           if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }

--- a/lib/services/beeper.dart
+++ b/lib/services/beeper.dart
@@ -1,7 +1,3 @@
-import 'dart:convert';
-import 'dart:math';
-import 'dart:typed_data';
-
 import 'package:audioplayers/audioplayers.dart';
 
 class Beeper {
@@ -9,73 +5,12 @@ class Beeper {
 
   static final AudioPlayer _player = AudioPlayer();
   static bool _configured = false;
-  static Uint8List? _cachedBeep;
-
-  static Future<void> _ensureConfigured() async {
-    if (_configured) {
-      return;
-    }
-    await _player.setReleaseMode(ReleaseMode.stop);
-    _configured = true;
-  }
 
   static Future<void> beep() async {
-    await _ensureConfigured();
-    _cachedBeep ??= _generateBeep();
-    await _player.play(BytesSource(_cachedBeep!));
-  }
-
-  static Uint8List _generateBeep() {
-    const sampleRate = 22050;
-    const frequency = 880.0;
-    const durationSeconds = 0.25;
-    const amplitude = 0.35;
-    final sampleCount = (sampleRate * durationSeconds).round();
-
-    final pcmDataBuilder = BytesBuilder();
-    for (var i = 0; i < sampleCount; i++) {
-      final time = i / sampleRate;
-      final sample = sin(2 * pi * frequency * time);
-      final amplitudeScaled = (sample * amplitude * 0x7fff).round();
-      pcmDataBuilder.add(_int16le(amplitudeScaled));
+    if (!_configured) {
+      await _player.setReleaseMode(ReleaseMode.stop);
+      _configured = true;
     }
-    final pcmData = pcmDataBuilder.toBytes();
-
-    final wavBuilder = BytesBuilder();
-    void writeString(String value) => wavBuilder.add(ascii.encode(value));
-    void writeInt32(int value) => wavBuilder.add(_int32le(value));
-    void writeInt16(int value) => wavBuilder.add(_int16le(value));
-
-    writeString('RIFF');
-    writeInt32(36 + pcmData.length);
-    writeString('WAVE');
-    writeString('fmt ');
-    writeInt32(16); // PCM chunk size
-    writeInt16(1); // audio format PCM
-    writeInt16(1); // channels
-    writeInt32(sampleRate);
-    writeInt32(sampleRate * 2); // byte rate (sampleRate * channels * bytesPerSample)
-    writeInt16(2); // block align (channels * bytesPerSample)
-    writeInt16(16); // bits per sample
-    writeString('data');
-    writeInt32(pcmData.length);
-    wavBuilder.add(pcmData);
-
-    return wavBuilder.toBytes();
-  }
-
-  static List<int> _int16le(int value) {
-    final v = value & 0xffff;
-    return [v & 0xff, (v >> 8) & 0xff];
-  }
-
-  static List<int> _int32le(int value) {
-    final v = value & 0xffffffff;
-    return [
-      v & 0xff,
-      (v >> 8) & 0xff,
-      (v >> 16) & 0xff,
-      (v >> 24) & 0xff,
-    ];
+    await _player.play(const AssetSource('audio/beep.mp3'));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ flutter:
     - assets/images/paw.png
     - assets/images/tick.png
     - assets/sounds/
+    - assets/audio/beep.mp3
     - assets/moro/moro_exercises.json
     - assets/quiz_questions_de.json
     - assets/quiz_questions_en.json

--- a/test/moro_timers_test.dart
+++ b/test/moro_timers_test.dart
@@ -56,6 +56,10 @@ void main() {
 
       await MoroSpeedStore.setOffsetForExercise(2, 1);
       expect(await MoroSpeedStore.getOffsetForExercise(2), 1);
+
+      final box = await Hive.openBox('moro_speed_offsets');
+      await box.put('offsets', {'5': 42});
+      expect(await MoroSpeedStore.getOffsetForExercise(5), 3);
     });
   });
 }


### PR DESCRIPTION
## Summary
- configure the beeper service to play the offline Moro asset tone
- expose the Moro beep asset in pubspec so Flutter bundles it
- route the dashboard training entry directly to the Moro screen to hide other phases

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fb82f962e8832db7f4c0f3a976f52c