### PR TITLE
Refactor training routes and onboarding guard

### DIFF
--- a/lib/features/common/dashboard_route_args.dart
+++ b/lib/features/common/dashboard_route_args.dart
@@ -1,0 +1,4 @@
+class DashboardRouteArgs {
+  final bool startTraining;
+  const DashboardRouteArgs({this.startTraining = false});
+}

--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -1,15 +1,35 @@
 // lib/features/common/dashboard_screen.dart
 
 import 'package:flutter/material.dart';
-import 'package:free_base/features/training/training_screen.dart';
-import 'package:free_base/features/calendar/screens/calendar_screen.dart';
+import 'package:free_base/features/common/dashboard_route_args.dart';
 import 'package:free_base/widgets/app_drawer.dart';
 
 /// DashboardScreen
 ///
 /// Startpunkt der App mit Navigation zu Training und Kalender.
-class DashboardScreen extends StatelessWidget {
+class DashboardScreen extends StatefulWidget {
   const DashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  bool _intentHandled = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_intentHandled) return;
+    _intentHandled = true;
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is DashboardRouteArgs && args.startTraining) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        Navigator.of(context).pushNamed('/training');
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,18 +43,12 @@ class DashboardScreen extends StatelessWidget {
             const Text('Willkommen im Dashboard!'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const TrainingScreen()),
-              ),
-              child: const Text('Zum Training'),
+              onPressed: () => Navigator.pushNamed(context, '/training'),
+              child: const Text('Training starten'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const CalendarScreen()),
-              ),
+              onPressed: () => Navigator.pushNamed(context, '/calendar'),
               child: const Text('Zum Kalender'),
             ),
           ],

--- a/lib/features/common/route_guard.dart
+++ b/lib/features/common/route_guard.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:free_base/features/onboarding/screens/login_screen.dart';
@@ -7,12 +8,111 @@ Route<dynamic> guard(
   WidgetBuilder authed, {
   WidgetBuilder? unauthed,
 }) {
-  final isLoggedIn = FirebaseAuth.instance.currentUser != null;
-  if (isLoggedIn) {
-    return MaterialPageRoute(builder: authed, settings: settings);
-  }
   return MaterialPageRoute(
-    builder: unauthed ?? (_) => const LoginScreen(),
+    builder: (context) => _GuardedRoute(
+      targetBuilder: authed,
+      unauthenticatedBuilder: unauthed,
+      settings: settings,
+    ),
     settings: settings,
   );
+}
+
+class _GuardedRoute extends StatefulWidget {
+  final WidgetBuilder targetBuilder;
+  final WidgetBuilder? unauthenticatedBuilder;
+  final RouteSettings settings;
+
+  const _GuardedRoute({
+    required this.targetBuilder,
+    required this.settings,
+    this.unauthenticatedBuilder,
+  });
+
+  @override
+  State<_GuardedRoute> createState() => _GuardedRouteState();
+}
+
+enum _GuardState { checking, authed, unauthed }
+
+class _GuardedRouteState extends State<_GuardedRoute> {
+  _GuardState _state = _GuardState.checking;
+
+  @override
+  void initState() {
+    super.initState();
+    _evaluateAccess();
+  }
+
+  Future<void> _evaluateAccess() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      setState(() => _state = _GuardState.unauthed);
+      return;
+    }
+
+    try {
+      final doc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .get();
+      final data = doc.data() ?? const <String, dynamic>{};
+      final role = (data['role'] as String?)?.trim();
+      final firstSessionCompleted =
+          (data['firstSessionCompleted'] as bool?) ?? false;
+
+      if (!mounted) return;
+
+      if (role == null || role.isEmpty) {
+        _redirectTo('/select-role');
+        return;
+      }
+
+      if (!_canBypassFirstSession(widget.settings.name) &&
+          !firstSessionCompleted) {
+        _redirectTo('/training');
+        return;
+      }
+
+      setState(() => _state = _GuardState.authed);
+    } catch (e) {
+      if (!mounted) return;
+      // Im Zweifel Nutzer durchlassen, damit Fehlerbildschirm greifen kann.
+      setState(() => _state = _GuardState.authed);
+    }
+  }
+
+  bool _canBypassFirstSession(String? routeName) {
+    if (routeName == null) return false;
+    if (routeName == '/training' || routeName == '/training/completed') {
+      return true;
+    }
+    if (routeName.startsWith('/training/moro')) {
+      return true;
+    }
+    return false;
+  }
+
+  void _redirectTo(String route) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      Navigator.of(context).pushReplacementNamed(route);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    switch (_state) {
+      case _GuardState.authed:
+        return widget.targetBuilder(context);
+      case _GuardState.unauthed:
+        final builder =
+            widget.unauthenticatedBuilder ?? (_) => const LoginScreen();
+        return builder(context);
+      case _GuardState.checking:
+        return const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        );
+    }
+  }
 }

--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'moro_models.dart';
+import 'timers.dart';
+
+class MoroExerciseScreenArgs {
+  final MoroExercise exercise;
+  final int offset;
+
+  const MoroExerciseScreenArgs({
+    required this.exercise,
+    required this.offset,
+  });
+}
+
+class MoroExerciseScreen extends StatefulWidget {
+  final MoroExercise exercise;
+  final int offset;
+
+  const MoroExerciseScreen({
+    super.key,
+    required this.exercise,
+    required this.offset,
+  });
+
+  @override
+  State<MoroExerciseScreen> createState() => _MoroExerciseScreenState();
+}
+
+class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
+  late final CancelToken _cancelToken;
+  StreamSubscription? _subscription;
+  int _repeat = 1;
+  int _phase = 1;
+  Duration _remaining = Duration.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    _cancelToken = CancelToken();
+    _startTimer();
+  }
+
+  void _startTimer() {
+    final ex = widget.exercise;
+    if (ex.type == MoroExerciseType.phased4x) {
+      final timer = PhasedMoroTimer(
+        repeats: ex.repeats,
+        phasesPerRepeat: ex.phasesPerRepeat,
+        phaseSeconds: ex.baseSeconds + widget.offset,
+      );
+      _subscription = timer.run(_cancelToken).listen((event) {
+        if (!mounted) return;
+        setState(() {
+          _repeat = event.repeatIdx;
+          _phase = event.phaseIdx;
+          _remaining = event.remaining;
+        });
+        if (event.done && mounted) {
+          Navigator.of(context).maybePop();
+        }
+      });
+    } else {
+      final timer = SimpleMoroTimer(
+        repeats: ex.repeats,
+        repeatSeconds: ex.baseSeconds + widget.offset,
+      );
+      _subscription = timer.run(_cancelToken).listen((event) {
+        if (!mounted) return;
+        setState(() {
+          _repeat = event.repeatIdx;
+          _phase = 1;
+          _remaining = event.remaining;
+        });
+        if (event.done && mounted) {
+          Navigator.of(context).maybePop();
+        }
+      });
+    }
+  }
+
+  double _segmentProgress() {
+    final totalSeconds = widget.exercise.baseSeconds + widget.offset;
+    if (totalSeconds <= 0) {
+      return 0;
+    }
+    final remainingMs = _remaining.inMilliseconds.clamp(0, totalSeconds * 1000);
+    return 1 - remainingMs / (totalSeconds * 1000);
+  }
+
+  Future<bool> _handleWillPop() async {
+    _cancelToken.cancel();
+    return true;
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _cancelToken.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ex = widget.exercise;
+    final phaseInfo = ex.type == MoroExerciseType.phased4x
+        ? 'Phase: $_phase / ${ex.phasesPerRepeat}'
+        : 'Aktive Wiederholung';
+
+    return WillPopScope(
+      onWillPop: _handleWillPop,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(ex.title),
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () {
+              _cancelToken.cancel();
+              Navigator.of(context).maybePop();
+            },
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Übung ${ex.index}', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 12),
+              Text('Wiederholung: $_repeat / ${ex.repeats}'),
+              const SizedBox(height: 4),
+              Text(phaseInfo),
+              const SizedBox(height: 24),
+              LinearProgressIndicator(value: _segmentProgress().clamp(0.0, 1.0)),
+              const SizedBox(height: 12),
+              Text('Restzeit: ${_remaining.inSeconds}s'),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: () {
+                    _cancelToken.cancel();
+                    Navigator.of(context).maybePop();
+                  },
+                  child: const Text('Abbrechen'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -1,9 +1,9 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
-import 'moro_repository.dart';
+
+import 'moro_exercise_screen.dart';
 import 'moro_models.dart';
+import 'moro_repository.dart';
 import 'moro_speed_store.dart';
-import 'timers.dart';
 
 class MoroTrainingScreen extends StatefulWidget {
   const MoroTrainingScreen({super.key});
@@ -62,9 +62,12 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
                     child: ListTile(
                       title: Text('${ex.index}. ${ex.title}'),
                       subtitle: Text(subtitle),
-                      leading: _SpeedChips(value: offs, onChanged: (v) => _setOffset(ex.index, v)),
+                      leading: _SpeedChips(
+                        value: offs,
+                        onChanged: (v) => _setOffset(ex.index, v),
+                      ),
                       trailing: ElevatedButton(
-                        onPressed: () => _startExercise(context, ex, offs),
+                        onPressed: () => _openExercise(context, ex, offs),
                         child: const Text('Start'),
                       ),
                     ),
@@ -78,12 +81,17 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     );
   }
 
-  Future<void> _startExercise(BuildContext context, MoroExercise ex, int offset) async {
-    final cancel = CancelToken();
-    await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => _MoroRunDialog(exercise: ex, offset: offset, cancel: cancel),
+  Future<void> _openExercise(
+    BuildContext context,
+    MoroExercise ex,
+    int offset,
+  ) async {
+    await Navigator.of(context).pushNamed(
+      '/training/moro/${ex.index}',
+      arguments: MoroExerciseScreenArgs(
+        exercise: ex,
+        offset: offset,
+      ),
     );
   }
 }
@@ -99,7 +107,10 @@ class _SpeedChips extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(value == 0 ? 'Standard' : '+${value}s', style: const TextStyle(fontSize: 12)),
+        Text(
+          value == 0 ? 'Standard' : '+${value}s',
+          style: const TextStyle(fontSize: 12),
+        ),
         Wrap(
           spacing: 6,
           children: opts.map((v) {
@@ -109,83 +120,6 @@ class _SpeedChips extends StatelessWidget {
               onSelected: (_) => onChanged(v),
             );
           }).toList(),
-        ),
-      ],
-    );
-  }
-}
-
-class _MoroRunDialog extends StatefulWidget {
-  final MoroExercise exercise;
-  final int offset;
-  final CancelToken cancel;
-  const _MoroRunDialog({required this.exercise, required this.offset, required this.cancel});
-
-  @override
-  State<_MoroRunDialog> createState() => _MoroRunDialogState();
-}
-
-class _MoroRunDialogState extends State<_MoroRunDialog> {
-  StreamSubscription? _sub;
-  int _r = 1;
-  int _p = 1;
-  Duration _rem = Duration.zero;
-
-  @override
-  void initState() {
-    super.initState();
-    if (widget.exercise.type == MoroExerciseType.phased4x) {
-      final t = PhasedMoroTimer(
-        repeats: widget.exercise.repeats,
-        phasesPerRepeat: widget.exercise.phasesPerRepeat,
-        phaseSeconds: widget.exercise.baseSeconds + widget.offset,
-      );
-      _sub = t.run(widget.cancel).listen((e) {
-        setState(() { _r = e.repeatIdx; _p = e.phaseIdx; _rem = e.remaining; });
-        if (e.done && mounted) Navigator.of(context).pop();
-      });
-    } else {
-      final t = SimpleMoroTimer(
-        repeats: widget.exercise.repeats,
-        repeatSeconds: widget.exercise.baseSeconds + widget.offset,
-      );
-      _sub = t.run(widget.cancel).listen((e) {
-        setState(() { _r = e.repeatIdx; _p = 1; _rem = e.remaining; });
-        if (e.done && mounted) Navigator.of(context).pop();
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final ex = widget.exercise;
-    return AlertDialog(
-      title: Text(ex.title),
-      content: SizedBox(
-        width: 320,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text('Wdh: $_r / ${ex.repeats}'),
-            if (ex.type == MoroExerciseType.phased4x)
-              Text('Phase: $_p / ${ex.phasesPerRepeat}'),
-            const SizedBox(height: 8),
-            Text('Rest: ${_rem.inSeconds}s'),
-            const SizedBox(height: 8),
-            const LinearProgressIndicator(),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () { widget.cancel.cancel(); Navigator.of(context).pop(); },
-          child: const Text('Abbrechen'),
         ),
       ],
     );

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -7,6 +7,8 @@
 /// - dynamischer Phasenwechsel
 
 import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:free_base/features/training/models/session_state.dart';
 import 'package:free_base/features/training/models/exercise_item.dart';
@@ -162,7 +164,42 @@ class SessionNotifier extends ChangeNotifier {
         notes: '',
       );
       _calendarService.addEvent(gdEvent);
+
+      _markFirstSessionCompleted();
     }
+  }
+
+  void restartSession() {
+    _timer?.cancel();
+    _timer = null;
+    _inRest = false;
+    if (_exercises.isEmpty) {
+      return;
+    }
+    final first = _exercises.first;
+    state = SessionState(
+      phaseId: state.phaseId,
+      exerciseIndex: 0,
+      completedReps: 0,
+      remainingSeconds: first.activeSeconds,
+      isPaused: true,
+      startedAt: DateTime.now(),
+    );
+    _phaseStart = state.startedAt;
+  }
+
+  void _markFirstSessionCompleted() {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      return;
+    }
+    // Fire-and-forget: der Guard liest das Flag beim nächsten Start.
+    unawaited(
+      FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .set({'firstSessionCompleted': true}, SetOptions(merge: true)),
+    );
   }
 
   @override

--- a/lib/features/training/training_completed_screen.dart
+++ b/lib/features/training/training_completed_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+
+class TrainingCompletedScreen extends StatelessWidget {
+  const TrainingCompletedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionNotifier = context.watch<SessionNotifier>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Training abgeschlossen')),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 24),
+            const Icon(Icons.emoji_events, size: 72, color: Colors.orangeAccent),
+            const SizedBox(height: 24),
+            Text(
+              'Starke Leistung!',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Du hast deine Session erfolgreich beendet. Nutze den Schwung für den nächsten Schritt oder kehre zum Dashboard zurück.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamedAndRemoveUntil(
+                    '/dashboard',
+                    (route) => route.isFirst,
+                  );
+                },
+                child: const Text('Zurück zum Dashboard'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () {
+                  sessionNotifier.restartSession();
+                  Navigator.of(context).pushReplacementNamed('/training');
+                },
+                child: const Text('Nächste Session planen'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/training/training_screen.dart
+++ b/lib/features/training/training_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:free_base/features/training/models/session_state.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/features/training/widgets/training_header.dart';
 import 'package:free_base/widgets/app_drawer.dart';
@@ -19,6 +20,16 @@ class TrainingScreen extends StatelessWidget {
     final exercises = sessionNotifier.exercises;
     final idx = state.exerciseIndex.clamp(0, exercises.length - 1);
     final current = exercises[idx];
+
+    if (state.status == SessionStatus.completed) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+        if (ModalRoute.of(context)?.settings.name == '/training/completed') {
+          return;
+        }
+        Navigator.of(context).pushReplacementNamed('/training/completed');
+      });
+    }
 
     return Scaffold(
       drawer: const AppDrawer(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,10 @@ import 'package:free_base/features/onboarding/screens/register_screen.dart';
 import 'package:free_base/features/onboarding/screens/role_selection_screen.dart';
 import 'package:free_base/features/common/dashboard_screen.dart';
 import 'package:free_base/features/onboarding/profile/settings_screen.dart';
+import 'package:free_base/features/training/moro/moro_exercise_screen.dart';
 import 'package:free_base/features/training/moro/moro_training_screen.dart';
+import 'package:free_base/features/training/training_completed_screen.dart';
+import 'package:free_base/features/training/training_screen.dart';
 import 'package:free_base/features/calendar/screens/calendar_screen.dart';
 import 'package:free_base/features/common/error_screen.dart';
 
@@ -180,7 +183,28 @@ class MyApp extends StatelessWidget {
         theme: ThemeData(primarySwatch: Colors.blue),
         initialRoute: '/',
         onGenerateRoute: (settings) {
-          switch (settings.name) {
+          final routeName = settings.name ?? '';
+
+          if (routeName.startsWith('/training/moro/')) {
+            final args = settings.arguments;
+            if (args is MoroExerciseScreenArgs) {
+              return guard(
+                settings,
+                (_) => MoroExerciseScreen(
+                  exercise: args.exercise,
+                  offset: args.offset,
+                ),
+              );
+            }
+            return MaterialPageRoute(
+              builder: (_) => const ErrorScreen(
+                message: 'Ungültige Trainingsparameter.',
+              ),
+              settings: settings,
+            );
+          }
+
+          switch (routeName) {
             case '/':
               return MaterialPageRoute(
                 builder: (_) => const SplashScreen(),
@@ -206,8 +230,11 @@ class MyApp extends StatelessWidget {
             case '/settings':
               return guard(settings, (_) => const SettingsScreen());
             case '/training':
+              return guard(settings, (_) => const TrainingScreen());
             case '/training/moro':
               return guard(settings, (_) => const MoroTrainingScreen());
+            case '/training/completed':
+              return guard(settings, (_) => const TrainingCompletedScreen());
             case '/calendar':
               return guard(settings, (_) => const CalendarScreen());
             case '/questionnaire':

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:free_base/constants/app_strings.dart';
+import 'package:free_base/features/common/dashboard_route_args.dart';
 import 'package:free_base/services/feature_flags.dart';
 
 class AppDrawer extends StatelessWidget {
@@ -22,10 +23,15 @@ class AppDrawer extends StatelessWidget {
       ),
       ListTile(
         leading: const Icon(Icons.fitness_center),
-        title: const Text('Training'),
+        title: const Text('Training (über Dashboard)'),
+        subtitle: const Text('Starte über den empfohlenen Ablauf'),
         onTap: () {
           Navigator.pop(context);
-          Navigator.pushNamed(context, '/training/moro');
+          Navigator.pushNamed(
+            context,
+            '/dashboard',
+            arguments: const DashboardRouteArgs(startTraining: true),
+          );
         },
       ),
       ListTile(


### PR DESCRIPTION
## Summary
- add onboarding-aware route guard that checks for selected roles and first-session completion before granting access
- reroute /training to the provider-backed TrainingScreen, add a training completion screen, and expose Moro exercise runs via dedicated subroutes
- update dashboard and drawer interactions to funnel users through the recommended training CTA while adding restart support in the session notifier

## Testing
- `flutter analyze` *(fails: command not found in container)*
- `dart format` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbc245d998832d86871d6f5d078a62