### PR TITLE
Add session status banner and completion dialog flows

### DIFF
--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -1,7 +1,11 @@
 // lib/features/common/dashboard_screen.dart
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'package:free_base/features/common/dashboard_route_args.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/widgets/session_status_banner.dart';
 import 'package:free_base/widgets/app_drawer.dart';
 
 /// DashboardScreen
@@ -23,6 +27,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
     if (_intentHandled) return;
     _intentHandled = true;
     final args = ModalRoute.of(context)?.settings.arguments;
+    context.read<SessionNotifier>().refreshScheduleStatus();
     if (args is DashboardRouteArgs && args.startTraining) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
@@ -33,23 +38,42 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final sessionNotifier = context.watch<SessionNotifier>();
+    final state = sessionNotifier.state;
     return Scaffold(
       drawer: const AppDrawer(),
       appBar: AppBar(title: const Text('Dashboard')),
-      body: Center(
+      body: Padding(
+        padding: const EdgeInsets.all(24),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('Willkommen im Dashboard!'),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Navigator.pushNamed(context, '/training'),
-              child: const Text('Training starten'),
+            SessionStatusBanner.fromSession(state),
+            const SizedBox(height: 24),
+            Text(
+              'Willkommen im Dashboard!',
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
             const SizedBox(height: 12),
-            ElevatedButton(
-              onPressed: () => Navigator.pushNamed(context, '/calendar'),
-              child: const Text('Zum Kalender'),
+            Text(
+              'Behalte deinen Trainingsfortschritt im Blick und starte deine nächste Einheit, wenn du bereit bist.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/training'),
+                child: const Text('Training starten'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () => Navigator.pushNamed(context, '/calendar'),
+                child: const Text('Zum Kalender'),
+              ),
             ),
           ],
         ),

--- a/lib/features/common/route_guard.dart
+++ b/lib/features/common/route_guard.dart
@@ -87,6 +87,9 @@ class _GuardedRouteState extends State<_GuardedRoute> {
     if (routeName == '/training' || routeName == '/training/completed') {
       return true;
     }
+    if (routeName == '/dashboard') {
+      return true;
+    }
     if (routeName.startsWith('/training/moro')) {
       return true;
     }

--- a/lib/features/training/models/session_state.dart
+++ b/lib/features/training/models/session_state.dart
@@ -2,7 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'session_state.freezed.dart';
 part 'session_state.g.dart';
 
-enum SessionStatus { inProgress, completed }
+enum SessionStatus { inProgress, completed, planned, overdue }
 
 @freezed
 class SessionState with _$SessionState {
@@ -14,7 +14,8 @@ class SessionState with _$SessionState {
     @Default(false) bool isPaused,
     required DateTime startedAt,
     DateTime? endAt,
-    @Default(SessionStatus.inProgress) SessionStatus status,
+    DateTime? plannedFor,
+    @Default(SessionStatus.planned) SessionStatus status,
   }) = _SessionState;
 
   factory SessionState.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/training/models/session_state.freezed.dart
+++ b/lib/features/training/models/session_state.freezed.dart
@@ -27,6 +27,7 @@ mixin _$SessionState {
   bool get isPaused => throw _privateConstructorUsedError;
   DateTime get startedAt => throw _privateConstructorUsedError;
   DateTime? get endAt => throw _privateConstructorUsedError;
+  DateTime? get plannedFor => throw _privateConstructorUsedError;
   SessionStatus get status => throw _privateConstructorUsedError;
 
   /// Serializes this SessionState to a JSON map.
@@ -53,6 +54,7 @@ abstract class $SessionStateCopyWith<$Res> {
       bool isPaused,
       DateTime startedAt,
       DateTime? endAt,
+      DateTime? plannedFor,
       SessionStatus status});
 }
 
@@ -78,6 +80,7 @@ class _$SessionStateCopyWithImpl<$Res, $Val extends SessionState>
     Object? isPaused = null,
     Object? startedAt = null,
     Object? endAt = freezed,
+    Object? plannedFor = freezed,
     Object? status = null,
   }) {
     return _then(_value.copyWith(
@@ -109,6 +112,10 @@ class _$SessionStateCopyWithImpl<$Res, $Val extends SessionState>
           ? _value.endAt
           : endAt // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      plannedFor: freezed == plannedFor
+          ? _value.plannedFor
+          : plannedFor // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
@@ -133,6 +140,7 @@ abstract class _$$SessionStateImplCopyWith<$Res>
       bool isPaused,
       DateTime startedAt,
       DateTime? endAt,
+      DateTime? plannedFor,
       SessionStatus status});
 }
 
@@ -156,6 +164,7 @@ class __$$SessionStateImplCopyWithImpl<$Res>
     Object? isPaused = null,
     Object? startedAt = null,
     Object? endAt = freezed,
+    Object? plannedFor = freezed,
     Object? status = null,
   }) {
     return _then(_$SessionStateImpl(
@@ -187,6 +196,10 @@ class __$$SessionStateImplCopyWithImpl<$Res>
           ? _value.endAt
           : endAt // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      plannedFor: freezed == plannedFor
+          ? _value.plannedFor
+          : plannedFor // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
@@ -206,7 +219,8 @@ class _$SessionStateImpl implements _SessionState {
       this.isPaused = false,
       required this.startedAt,
       this.endAt,
-      this.status = SessionStatus.inProgress});
+      this.plannedFor,
+      this.status = SessionStatus.planned});
 
   factory _$SessionStateImpl.fromJson(Map<String, dynamic> json) =>
       _$$SessionStateImplFromJson(json);
@@ -227,12 +241,14 @@ class _$SessionStateImpl implements _SessionState {
   @override
   final DateTime? endAt;
   @override
+  final DateTime? plannedFor;
+  @override
   @JsonKey()
   final SessionStatus status;
 
   @override
   String toString() {
-    return 'SessionState(phaseId: $phaseId, exerciseIndex: $exerciseIndex, completedReps: $completedReps, remainingSeconds: $remainingSeconds, isPaused: $isPaused, startedAt: $startedAt, endAt: $endAt, status: $status)';
+    return 'SessionState(phaseId: $phaseId, exerciseIndex: $exerciseIndex, completedReps: $completedReps, remainingSeconds: $remainingSeconds, isPaused: $isPaused, startedAt: $startedAt, endAt: $endAt, plannedFor: $plannedFor, status: $status)';
   }
 
   @override
@@ -252,13 +268,16 @@ class _$SessionStateImpl implements _SessionState {
             (identical(other.startedAt, startedAt) ||
                 other.startedAt == startedAt) &&
             (identical(other.endAt, endAt) || other.endAt == endAt) &&
+            (identical(other.plannedFor, plannedFor) ||
+                other.plannedFor == plannedFor) &&
             (identical(other.status, status) || other.status == status));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, phaseId, exerciseIndex,
-      completedReps, remainingSeconds, isPaused, startedAt, endAt, status);
+      completedReps, remainingSeconds, isPaused, startedAt, endAt, plannedFor,
+      status);
 
   /// Create a copy of SessionState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/features/training/models/session_state.g.dart
+++ b/lib/features/training/models/session_state.g.dart
@@ -17,8 +17,11 @@ _$SessionStateImpl _$$SessionStateImplFromJson(Map<String, dynamic> json) =>
       endAt: json['endAt'] == null
           ? null
           : DateTime.parse(json['endAt'] as String),
+      plannedFor: json['plannedFor'] == null
+          ? null
+          : DateTime.parse(json['plannedFor'] as String),
       status: $enumDecodeNullable(_$SessionStatusEnumMap, json['status']) ??
-          SessionStatus.inProgress,
+          SessionStatus.planned,
     );
 
 Map<String, dynamic> _$$SessionStateImplToJson(_$SessionStateImpl instance) =>
@@ -30,10 +33,13 @@ Map<String, dynamic> _$$SessionStateImplToJson(_$SessionStateImpl instance) =>
       'isPaused': instance.isPaused,
       'startedAt': instance.startedAt.toIso8601String(),
       'endAt': instance.endAt?.toIso8601String(),
+      'plannedFor': instance.plannedFor?.toIso8601String(),
       'status': _$SessionStatusEnumMap[instance.status]!,
     };
 
 const _$SessionStatusEnumMap = {
   SessionStatus.inProgress: 'inProgress',
   SessionStatus.completed: 'completed',
+  SessionStatus.planned: 'planned',
+  SessionStatus.overdue: 'overdue',
 };

--- a/lib/features/training/models/session_state_adapter.dart
+++ b/lib/features/training/models/session_state_adapter.dart
@@ -35,6 +35,12 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
 
     final status = reader.read() as SessionStatus;
 
+    DateTime? plannedFor;
+    if (reader.availableBytes > 0) {
+      final hasPlannedFor = reader.readBool();
+      plannedFor = hasPlannedFor ? reader.read() as DateTime : null;
+    }
+
     return SessionState(
       phaseId: phaseId,
       exerciseIndex: exerciseIndex,
@@ -44,6 +50,7 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
       startedAt: startedAt,
       endAt: endAt,
       status: status,
+      plannedFor: plannedFor,
     );
   }
 
@@ -64,5 +71,12 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
     }
 
     writer.write(obj.status);
+
+    if (obj.plannedFor != null) {
+      writer.writeBool(true);
+      writer.write(obj.plannedFor!);
+    } else {
+      writer.writeBool(false);
+    }
   }
 }

--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -15,6 +15,16 @@ class MoroExerciseScreenArgs {
   });
 }
 
+class MoroExerciseResult {
+  final bool completed;
+  final Duration? duration;
+
+  const MoroExerciseResult({
+    required this.completed,
+    this.duration,
+  });
+}
+
 class MoroExerciseScreen extends StatefulWidget {
   final MoroExercise exercise;
   final int offset;
@@ -51,6 +61,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         phasesPerRepeat: ex.phasesPerRepeat,
         phaseSeconds: ex.baseSeconds + widget.offset,
       );
+      final totalDuration = timer.totalDuration;
       _subscription = timer.run(_cancelToken).listen((event) {
         if (!mounted) return;
         setState(() {
@@ -59,7 +70,12 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
           _remaining = event.remaining;
         });
         if (event.done && mounted) {
-          Navigator.of(context).maybePop();
+          Navigator.of(context).maybePop(
+            MoroExerciseResult(
+              completed: true,
+              duration: totalDuration,
+            ),
+          );
         }
       });
     } else {
@@ -67,6 +83,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         repeats: ex.repeats,
         repeatSeconds: ex.baseSeconds + widget.offset,
       );
+      final totalDuration = timer.totalDuration;
       _subscription = timer.run(_cancelToken).listen((event) {
         if (!mounted) return;
         setState(() {
@@ -75,7 +92,12 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
           _remaining = event.remaining;
         });
         if (event.done && mounted) {
-          Navigator.of(context).maybePop();
+          Navigator.of(context).maybePop(
+            MoroExerciseResult(
+              completed: true,
+              duration: totalDuration,
+            ),
+          );
         }
       });
     }
@@ -92,7 +114,8 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
 
   Future<bool> _handleWillPop() async {
     _cancelToken.cancel();
-    return true;
+    Navigator.of(context).pop(const MoroExerciseResult(completed: false));
+    return false;
   }
 
   @override
@@ -118,7 +141,8 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
             icon: const Icon(Icons.close),
             onPressed: () {
               _cancelToken.cancel();
-              Navigator.of(context).maybePop();
+              Navigator.of(context)
+                  .maybePop(const MoroExerciseResult(completed: false));
             },
           ),
         ),
@@ -142,7 +166,8 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
                 child: OutlinedButton(
                   onPressed: () {
                     _cancelToken.cancel();
-                    Navigator.of(context).maybePop();
+                    Navigator.of(context)
+                        .maybePop(const MoroExerciseResult(completed: false));
                   },
                   child: const Text('Abbrechen'),
                 ),

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:free_base/features/training/widgets/session_completion_dialog.dart';
+
 import 'moro_exercise_screen.dart';
 import 'moro_models.dart';
 import 'moro_repository.dart';
@@ -86,13 +88,43 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     MoroExercise ex,
     int offset,
   ) async {
-    await Navigator.of(context).pushNamed(
+    final result = await Navigator.of(context).pushNamed(
       '/training/moro/${ex.index}',
       arguments: MoroExerciseScreenArgs(
         exercise: ex,
         offset: offset,
       ),
     );
+    if (!mounted) return;
+    if (result is MoroExerciseResult && result.completed) {
+      final summary = SessionCompletionSummary(
+        totalDuration: result.duration ?? const Duration(),
+        totalExercises: 1,
+        totalRepetitions: ex.repeats,
+        phaseLabel: ex.title,
+      );
+      final action = await showSessionCompletionDialog(
+        context,
+        summary: summary,
+      );
+      if (!mounted) return;
+      switch (action) {
+        case SessionCompletionAction.openCalendar:
+          Navigator.of(context).pushNamed('/calendar');
+          break;
+        case SessionCompletionAction.giveFeedback:
+          Navigator.of(context).pushNamed('/questionnaire');
+          break;
+        case SessionCompletionAction.planNext:
+        case SessionCompletionAction.close:
+        case null:
+          Navigator.of(context).pushNamedAndRemoveUntil(
+            '/dashboard',
+            (route) => route.isFirst,
+          );
+          break;
+      }
+    }
   }
 }
 

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -48,7 +48,9 @@ class SessionNotifier extends ChangeNotifier {
     SessionState state,
   )   : _exercises = initialExercises,
         _state = state,
-        _phaseStart = state.startedAt;
+        _phaseStart = state.startedAt {
+    refreshScheduleStatus();
+  }
 
   SessionState get state => _state;
   List<ExerciseItem> get exercises => _exercises;
@@ -64,7 +66,21 @@ class SessionNotifier extends ChangeNotifier {
   void start() {
     if (_timer != null) return;
     if (state.status == SessionStatus.completed) {
-      state = state.copyWith(status: SessionStatus.inProgress);
+      state = state.copyWith(
+        status: SessionStatus.inProgress,
+        startedAt: DateTime.now(),
+        plannedFor: null,
+        endAt: null,
+      );
+    }
+    if (state.status == SessionStatus.planned ||
+        state.status == SessionStatus.overdue) {
+      state = state.copyWith(
+        status: SessionStatus.inProgress,
+        startedAt: DateTime.now(),
+        plannedFor: null,
+        endAt: null,
+      );
     }
     state = state.copyWith(isPaused: false);
     _timer = Timer.periodic(const Duration(seconds: 1), _tick);
@@ -85,15 +101,18 @@ class SessionNotifier extends ChangeNotifier {
     _weeklyCounts.clear();
     _exercises = _exerciseRepo.getExercisesForPhase(newPhaseId);
     final first = _exercises.first;
+    final plannedFor = DateTime.now().add(const Duration(days: 1));
     state = SessionState(
       phaseId: newPhaseId,
       exerciseIndex: 0,
       completedReps: 0,
       remainingSeconds: first.activeSeconds,
       isPaused: true,
-      startedAt: DateTime.now(),
+      startedAt: plannedFor,
+      plannedFor: plannedFor,
+      status: SessionStatus.planned,
     );
-    _phaseStart = state.startedAt;
+    _phaseStart = DateTime.now();
   }
 
   void _tick(Timer timer) {
@@ -142,6 +161,7 @@ class SessionNotifier extends ChangeNotifier {
       state = state.copyWith(
         status: SessionStatus.completed,
         endAt: DateTime.now(),
+        plannedFor: null,
       );
       // Kalender-Event erstellen statt undefined addSessionEvent
       final event = CalendarEvent.fromSession(state);
@@ -169,7 +189,11 @@ class SessionNotifier extends ChangeNotifier {
     }
   }
 
-  void restartSession() {
+  void restartSession({DateTime? plannedFor}) {
+    scheduleNextSession(plannedFor: plannedFor);
+  }
+
+  void scheduleNextSession({DateTime? plannedFor}) {
     _timer?.cancel();
     _timer = null;
     _inRest = false;
@@ -177,15 +201,26 @@ class SessionNotifier extends ChangeNotifier {
       return;
     }
     final first = _exercises.first;
-    state = SessionState(
-      phaseId: state.phaseId,
+    final target = plannedFor ?? DateTime.now().add(const Duration(days: 1));
+    state = state.copyWith(
       exerciseIndex: 0,
       completedReps: 0,
       remainingSeconds: first.activeSeconds,
       isPaused: true,
-      startedAt: DateTime.now(),
+      startedAt: target,
+      plannedFor: target,
+      endAt: null,
+      status: SessionStatus.planned,
     );
-    _phaseStart = state.startedAt;
+    _phaseStart = DateTime.now();
+  }
+
+  void refreshScheduleStatus() {
+    if (state.status == SessionStatus.planned && state.plannedFor != null) {
+      if (DateTime.now().isAfter(state.plannedFor!)) {
+        state = state.copyWith(status: SessionStatus.overdue);
+      }
+    }
   }
 
   void _markFirstSessionCompleted() {

--- a/lib/features/training/screens/phase_selection_screen.dart
+++ b/lib/features/training/screens/phase_selection_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:free_base/features/training/services/exercise_repository.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/widgets/app_drawer.dart';
+import 'package:free_base/widgets/info_card.dart';
 
 class PhaseSelectionScreen extends StatelessWidget {
   const PhaseSelectionScreen({super.key});
@@ -13,18 +14,32 @@ class PhaseSelectionScreen extends StatelessWidget {
     return Scaffold(
       drawer: const AppDrawer(),
       appBar: AppBar(title: const Text('Phase auswählen')),
-      body: ListView.builder(
-        itemCount: phases.length,
-        itemBuilder: (ctx, i) {
-          final id = phases[i];
-          return ListTile(
-            title: Text('Phase $id'),
-            onTap: () {
-              context.read<SessionNotifier>().changePhase(id);
-              Navigator.of(context).pop();
-            },
-          );
-        },
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const InfoCard(
+            title: 'Phase wählen',
+            description:
+                'Wähle die Phase, die zu deinem aktuellen Trainingsplan passt. Jede Phase baut aufeinander auf und bringt neue Übungen sowie angepasste Wiederholungsziele mit sich.',
+            icon: Icons.flag_outlined,
+          ),
+          const SizedBox(height: 16),
+          ...phases.map((id) {
+            return Card(
+              child: ListTile(
+                title: Text('Phase $id'),
+                subtitle: const Text(
+                  'Zeigt dir die passenden Übungen und Tagesziele an.',
+                ),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () {
+                  context.read<SessionNotifier>().changePhase(id);
+                  Navigator.of(context).pop();
+                },
+              ),
+            );
+          }),
+        ],
       ),
     );
   }

--- a/lib/features/training/screens/training_help_screen.dart
+++ b/lib/features/training/screens/training_help_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
+import 'package:free_base/widgets/info_card.dart';
+
 import '../services/exercise_repository.dart';
 
 class TrainingHelpScreen extends StatefulWidget {
@@ -14,6 +16,8 @@ class TrainingHelpScreen extends StatefulWidget {
 
 class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
   VideoPlayerController? _controller;
+  bool _isLoading = false;
+  String? _error;
 
   /// Mapping 'phase-exercise' → asset path
   final Map<String, String> _videoPaths = {
@@ -24,10 +28,25 @@ class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
     final path = _videoPaths[key];
     if (path == null) return;
     await _controller?.dispose();
-    _controller = VideoPlayerController.asset(path);
-    await _controller!.initialize();
-    setState(() {});
-    await _controller!.play();
+    setState(() {
+      _isLoading = true;
+      _error = null;
+      _controller = VideoPlayerController.asset(path);
+    });
+    try {
+      await _controller!.initialize();
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+      });
+      await _controller!.play();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Video konnte nicht geladen werden: $e';
+      });
+    }
   }
 
   @override
@@ -46,7 +65,15 @@ class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            InfoCard(
+              title: 'Übungsübersicht für Phase ${widget.phaseId}',
+              description:
+                  'Tippe auf eine Übung, um das passende Demonstrationsvideo zu starten. Die Clips helfen dir bei Technik, Rhythmus und Tempo.',
+              icon: Icons.ondemand_video_outlined,
+            ),
+            const SizedBox(height: 16),
             Wrap(
               spacing: 8,
               runSpacing: 8,
@@ -56,16 +83,45 @@ class _TrainingHelpScreenState extends State<TrainingHelpScreen> {
                   key: Key('help_btn_$num'),
                   onPressed: () =>
                       _playVideo('${widget.phaseId}-$num'),
-                  child: Text('$num'),
+                  child: Text('Übung $num'),
                 );
               }),
             ),
             const SizedBox(height: 16),
-            if (_controller != null && _controller!.value.isInitialized)
-              AspectRatio(
-                aspectRatio: _controller!.value.aspectRatio,
-                child: VideoPlayer(_controller!),
+            Expanded(
+              child: Builder(
+                builder: (context) {
+                  if (_isLoading) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  if (_error != null) {
+                    return Center(
+                      child: Text(
+                        _error!,
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color:
+                                  Theme.of(context).colorScheme.error,
+                            ),
+                      ),
+                    );
+                  }
+                  if (_controller != null &&
+                      _controller!.value.isInitialized) {
+                    return AspectRatio(
+                      aspectRatio: _controller!.value.aspectRatio,
+                      child: VideoPlayer(_controller!),
+                    );
+                  }
+                  return Center(
+                    child: Text(
+                      'Wähle eine Übung, um das Video zu starten.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  );
+                },
               ),
+            ),
           ],
         ),
       ),

--- a/lib/features/training/services/sync_service.dart
+++ b/lib/features/training/services/sync_service.dart
@@ -11,6 +11,9 @@ class SyncService {
   final String _userId; // zum Pfad in Firestore
   final List<SessionState> _queue = [];
 
+  final StreamController<SyncStatusEvent> _statusController =
+      StreamController<SyncStatusEvent>.broadcast();
+
   late final StreamSubscription<ConnectivityResult> _connSub;
 
   SyncService(this._repo, this._firestore, this._userId) {
@@ -24,7 +27,10 @@ class SyncService {
 
   Future<void> dispose() async {
     await _connSub.cancel();
+    await _statusController.close();
   }
+
+  Stream<SyncStatusEvent> get statusStream => _statusController.stream;
 
   Future<void> _loadQueue() async {
     final current = await _repo.load();
@@ -59,10 +65,26 @@ class SyncService {
             .doc(state.startedAt.toIso8601String())
             .set(state.toJson());
         _queue.removeAt(0);
+        _statusController.add(SyncStatusEvent.success(state));
       } catch (e) {
         // Bei Fehler abbrechen und später erneut versuchen
+        _statusController.add(SyncStatusEvent.failure(state, e));
         break;
       }
     }
   }
+}
+
+class SyncStatusEvent {
+  final SessionState state;
+  final bool success;
+  final Object? error;
+
+  const SyncStatusEvent._(this.state, this.success, this.error);
+
+  factory SyncStatusEvent.success(SessionState state) =>
+      SyncStatusEvent._(state, true, null);
+
+  factory SyncStatusEvent.failure(SessionState state, Object error) =>
+      SyncStatusEvent._(state, false, error);
 }

--- a/lib/features/training/training_screen.dart
+++ b/lib/features/training/training_screen.dart
@@ -3,15 +3,73 @@ import 'package:provider/provider.dart';
 
 import 'package:free_base/features/training/models/session_state.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/widgets/control_button_row.dart';
+import 'package:free_base/features/training/widgets/exercise_canvas.dart';
+import 'package:free_base/features/training/widgets/progress_row.dart';
+import 'package:free_base/features/training/widgets/session_completion_dialog.dart';
+import 'package:free_base/features/training/widgets/session_status_banner.dart';
 import 'package:free_base/features/training/widgets/training_header.dart';
 import 'package:free_base/widgets/app_drawer.dart';
-import 'package:free_base/features/training/widgets/progress_row.dart';
-import 'package:free_base/features/training/widgets/exercise_canvas.dart';
-import 'package:free_base/features/training/widgets/control_button_row.dart';
 import 'package:free_base/widgets/connectivity_banner.dart';
 
-class TrainingScreen extends StatelessWidget {
+class TrainingScreen extends StatefulWidget {
   const TrainingScreen({super.key});
+
+  @override
+  State<TrainingScreen> createState() => _TrainingScreenState();
+}
+
+class _TrainingScreenState extends State<TrainingScreen> {
+  bool _dialogShown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    context.read<SessionNotifier>().refreshScheduleStatus();
+  }
+
+  Future<void> _handleCompletion(
+      SessionNotifier notifier, SessionState state) async {
+    if (_dialogShown) return;
+    _dialogShown = true;
+    final exercises = notifier.exercises;
+    final totalReps = exercises.fold<int>(0, (sum, ex) => sum + ex.repetitions);
+    final duration = state.endAt != null
+        ? state.endAt!.difference(state.startedAt)
+        : const Duration();
+    final action = await showSessionCompletionDialog(
+      context,
+      summary: SessionCompletionSummary(
+        totalDuration: duration,
+        totalExercises: exercises.length,
+        totalRepetitions: totalReps,
+        phaseLabel: 'Phase ${state.phaseId}',
+      ),
+    );
+    if (!mounted) return;
+    notifier.scheduleNextSession();
+    switch (action) {
+      case SessionCompletionAction.openCalendar:
+        Navigator.of(context).pushNamed('/calendar');
+        break;
+      case SessionCompletionAction.giveFeedback:
+        Navigator.of(context).pushNamed('/questionnaire');
+        break;
+      case SessionCompletionAction.planNext:
+      case SessionCompletionAction.close:
+      case null:
+        Navigator.of(context).pushNamedAndRemoveUntil(
+          '/dashboard',
+          (route) => route.isFirst,
+        );
+        break;
+    }
+    if (mounted) {
+      setState(() {
+        _dialogShown = false;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,14 +79,15 @@ class TrainingScreen extends StatelessWidget {
     final idx = state.exerciseIndex.clamp(0, exercises.length - 1);
     final current = exercises[idx];
 
-    if (state.status == SessionStatus.completed) {
+    if (state.status == SessionStatus.completed && !_dialogShown) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!context.mounted) return;
-        if (ModalRoute.of(context)?.settings.name == '/training/completed') {
-          return;
-        }
-        Navigator.of(context).pushReplacementNamed('/training/completed');
+        if (!mounted) return;
+        _handleCompletion(sessionNotifier, state);
       });
+    }
+
+    if (state.status != SessionStatus.completed && _dialogShown) {
+      _dialogShown = false;
     }
 
     return Scaffold(
@@ -40,6 +99,10 @@ class TrainingScreen extends StatelessWidget {
       body: Column(
         children: [
           const ConnectivityBanner(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: SessionStatusBanner.fromSession(state),
+          ),
           ProgressRow(
             currentExercise: idx + 1,
             totalExercises: exercises.length,

--- a/lib/features/training/widgets/session_completion_dialog.dart
+++ b/lib/features/training/widgets/session_completion_dialog.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+class SessionCompletionSummary {
+  final Duration totalDuration;
+  final int totalExercises;
+  final int totalRepetitions;
+  final String? phaseLabel;
+
+  const SessionCompletionSummary({
+    required this.totalDuration,
+    required this.totalExercises,
+    required this.totalRepetitions,
+    this.phaseLabel,
+  });
+}
+
+enum SessionCompletionAction { close, planNext, openCalendar, giveFeedback }
+
+Future<SessionCompletionAction?> showSessionCompletionDialog(
+  BuildContext context, {
+  required SessionCompletionSummary summary,
+}) {
+  final duration = summary.totalDuration;
+  final durationLabel = duration == Duration.zero
+      ? 'Weniger als eine Minute'
+      : _formatDuration(duration);
+
+  return showDialog<SessionCompletionAction>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) {
+      return AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: Row(
+          children: [
+            const Icon(Icons.emoji_events, color: Colors.orangeAccent, size: 32),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Session abgeschlossen',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleLarge
+                    ?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Starke Leistung! Du hast deine aktuelle Trainingseinheit erfolgreich beendet.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            if (summary.phaseLabel != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                summary.phaseLabel!,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ],
+            const SizedBox(height: 16),
+            _StatTile(
+              icon: Icons.timer_outlined,
+              label: 'Gesamtdauer',
+              value: durationLabel,
+            ),
+            const SizedBox(height: 8),
+            _StatTile(
+              icon: Icons.fitness_center_outlined,
+              label: 'Übungen abgeschlossen',
+              value: '${summary.totalExercises}',
+            ),
+            const SizedBox(height: 8),
+            _StatTile(
+              icon: Icons.repeat,
+              label: 'Wiederholungen',
+              value: '${summary.totalRepetitions}',
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context)
+                .pop(SessionCompletionAction.giveFeedback),
+            child: const Text('Feedback geben'),
+          ),
+          TextButton(
+            onPressed: () =>
+                Navigator.of(context).pop(SessionCompletionAction.openCalendar),
+            child: const Text('Zum Kalender'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context)
+                .pop(SessionCompletionAction.planNext),
+            child: const Text('Nächste Session planen'),
+          ),
+        ],
+      );
+    },
+  );
+}
+
+String _formatDuration(Duration duration) {
+  final minutes = duration.inMinutes;
+  final seconds = duration.inSeconds % 60;
+  if (minutes <= 0) {
+    return '${duration.inSeconds}s';
+  }
+  if (seconds == 0) {
+    return '${minutes}min';
+  }
+  return '${minutes}min ${seconds}s';
+}
+
+class _StatTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _StatTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Icon(icon, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(label, style: Theme.of(context).textTheme.bodySmall),
+              Text(
+                value,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/training/widgets/session_status_banner.dart
+++ b/lib/features/training/widgets/session_status_banner.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:free_base/features/training/models/session_state.dart';
+
+enum SessionStatusBannerState { planned, inProgress, overdue }
+
+class SessionStatusBanner extends StatelessWidget {
+  final SessionStatusBannerState status;
+  final String title;
+  final String? subtitle;
+  final VoidCallback? onTap;
+
+  const SessionStatusBanner({
+    super.key,
+    required this.status,
+    required this.title,
+    this.subtitle,
+    this.onTap,
+  });
+
+  factory SessionStatusBanner.fromSession(SessionState state) {
+    final resolved = _resolveStatus(state);
+    return SessionStatusBanner(
+      status: resolved,
+      title: _buildTitle(resolved),
+      subtitle: _buildSubtitle(resolved, state),
+    );
+  }
+
+  static SessionStatusBannerState _resolveStatus(SessionState state) {
+    if (state.status == SessionStatus.inProgress && !state.isPaused) {
+      return SessionStatusBannerState.inProgress;
+    }
+    if (state.status == SessionStatus.inProgress && state.completedReps > 0) {
+      return SessionStatusBannerState.inProgress;
+    }
+    if (state.status == SessionStatus.overdue) {
+      return SessionStatusBannerState.overdue;
+    }
+    if (state.status == SessionStatus.planned) {
+      if (state.plannedFor != null &&
+          DateTime.now().isAfter(state.plannedFor!)) {
+        return SessionStatusBannerState.overdue;
+      }
+      return SessionStatusBannerState.planned;
+    }
+    if (state.status == SessionStatus.completed) {
+      return SessionStatusBannerState.planned;
+    }
+    return SessionStatusBannerState.planned;
+  }
+
+  static String _buildTitle(SessionStatusBannerState status) {
+    switch (status) {
+      case SessionStatusBannerState.inProgress:
+        return 'Session in Bearbeitung';
+      case SessionStatusBannerState.overdue:
+        return 'Session überfällig';
+      case SessionStatusBannerState.planned:
+      default:
+        return 'Session geplant';
+    }
+  }
+
+  static String? _buildSubtitle(
+      SessionStatusBannerState status, SessionState state) {
+    final plannedFor = state.plannedFor;
+    switch (status) {
+      case SessionStatusBannerState.inProgress:
+        return state.isPaused
+            ? 'Du hast pausiert. Setze fort, wenn du bereit bist.'
+            : 'Weiter so! Beende deine aktuelle Session.';
+      case SessionStatusBannerState.overdue:
+        if (plannedFor != null) {
+          return 'Geplant für ${DateFormat.yMMMMd().format(plannedFor)} um '
+              '${DateFormat.Hm().format(plannedFor)}';
+        }
+        return 'Starte deine Session, um wieder im Plan zu sein.';
+      case SessionStatusBannerState.planned:
+      default:
+        if (plannedFor != null) {
+          if (plannedFor.isAfter(DateTime.now())) {
+            return 'Geplant für ${DateFormat.yMMMMd().format(plannedFor)}';
+          }
+          return 'Bereit sobald du startest.';
+        }
+        return 'Plane deine nächste Session, wenn es für dich passt.';
+    }
+  }
+
+  Color _backgroundColor(BuildContext context) {
+    switch (status) {
+      case SessionStatusBannerState.inProgress:
+        return Theme.of(context).colorScheme.primary.withOpacity(0.12);
+      case SessionStatusBannerState.overdue:
+        return Theme.of(context).colorScheme.error.withOpacity(0.12);
+      case SessionStatusBannerState.planned:
+      default:
+        return Theme.of(context).colorScheme.secondary.withOpacity(0.12);
+    }
+  }
+
+  Color _borderColor(BuildContext context) {
+    switch (status) {
+      case SessionStatusBannerState.inProgress:
+        return Theme.of(context).colorScheme.primary;
+      case SessionStatusBannerState.overdue:
+        return Theme.of(context).colorScheme.error;
+      case SessionStatusBannerState.planned:
+      default:
+        return Theme.of(context).colorScheme.secondary;
+    }
+  }
+
+  IconData _icon() {
+    switch (status) {
+      case SessionStatusBannerState.inProgress:
+        return Icons.play_circle_fill;
+      case SessionStatusBannerState.overdue:
+        return Icons.warning_amber_rounded;
+      case SessionStatusBannerState.planned:
+      default:
+        return Icons.schedule;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          _icon(),
+          color: _borderColor(context),
+          size: 28,
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              if (subtitle != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  subtitle!,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: _backgroundColor(context),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: _borderColor(context)),
+          ),
+          child: content,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/training/widgets/session_sync_listener.dart
+++ b/lib/features/training/widgets/session_sync_listener.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/features/training/services/sync_service.dart';
+
+class SessionSyncListener extends StatefulWidget {
+  final Widget child;
+  final GlobalKey<ScaffoldMessengerState> messengerKey;
+
+  const SessionSyncListener({
+    super.key,
+    required this.child,
+    required this.messengerKey,
+  });
+
+  @override
+  State<SessionSyncListener> createState() => _SessionSyncListenerState();
+}
+
+class _SessionSyncListenerState extends State<SessionSyncListener> {
+  StreamSubscription<SyncStatusEvent>? _subscription;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _subscription?.cancel();
+    final syncService = context.read<SyncService>();
+    _subscription = syncService.statusStream.listen(_handleEvent);
+  }
+
+  void _handleEvent(SyncStatusEvent event) {
+    final messenger = widget.messengerKey.currentState;
+    if (messenger == null) {
+      return;
+    }
+    final theme = messenger.context.theme;
+    final isSuccess = event.success;
+    final backgroundColor = isSuccess
+        ? theme.colorScheme.primaryContainer
+        : theme.colorScheme.errorContainer;
+    final icon = isSuccess ? Icons.cloud_done : Icons.cloud_off;
+    final textColor = isSuccess
+        ? theme.colorScheme.onPrimaryContainer
+        : theme.colorScheme.onErrorContainer;
+    final message = isSuccess
+        ? 'Session erfolgreich synchronisiert.'
+        : 'Synchronisation fehlgeschlagen. Versuche es später erneut.';
+
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        backgroundColor: backgroundColor,
+        behavior: SnackBarBehavior.floating,
+        content: Row(
+          children: [
+            Icon(icon, color: theme.colorScheme.onPrimaryContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                message,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: textColor,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+extension on BuildContext {
+  ThemeData get theme => Theme.of(this);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:free_base/features/training/services/session_repository.dart';
 import 'package:free_base/features/training/services/sync_service.dart';
 import 'package:free_base/features/training/services/exercise_repository.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/widgets/session_sync_listener.dart';
 
 import 'package:free_base/features/calendar/models/calendar_event.dart';
 import 'package:free_base/features/calendar/models/calendar_event_adapter.dart';
@@ -99,14 +100,17 @@ Future<void> main() async {
 
   final sessionRepository = SessionRepository();
   final savedSession = await sessionRepository.load();
+  final plannedFor = DateTime.now().add(const Duration(days: 1));
   final initialSessionState = savedSession ??
       SessionState(
         phaseId: '0',
         exerciseIndex: 0,
         completedReps: 0,
         remainingSeconds: 8,
-        isPaused: false,
-        startedAt: DateTime.now(),
+        isPaused: true,
+        startedAt: plannedFor,
+        plannedFor: plannedFor,
+        status: SessionStatus.planned,
       );
 
   runApp(
@@ -120,8 +124,10 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   final SessionRepository sessionRepository;
   final SessionState initialSessionState;
+  final GlobalKey<ScaffoldMessengerState> _scaffoldMessengerKey =
+      GlobalKey<ScaffoldMessengerState>();
 
-  const MyApp({
+  MyApp({
     super.key,
     required this.sessionRepository,
     required this.initialSessionState,
@@ -181,6 +187,11 @@ class MyApp extends StatelessWidget {
       child: MaterialApp(
         title: AppStrings.appName,
         theme: ThemeData(primarySwatch: Colors.blue),
+        scaffoldMessengerKey: _scaffoldMessengerKey,
+        builder: (context, child) => SessionSyncListener(
+          messengerKey: _scaffoldMessengerKey,
+          child: child ?? const SizedBox.shrink(),
+        ),
         initialRoute: '/',
         onGenerateRoute: (settings) {
           final routeName = settings.name ?? '';

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class InfoCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final IconData icon;
+
+  const InfoCard({
+    super.key,
+    required this.title,
+    required this.description,
+    this.icon = Icons.info_outline,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: theme.colorScheme.outlineVariant,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: theme.colorScheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  description,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extend session scheduling metadata with planned and overdue states and surface a reusable SessionStatusBanner on the dashboard and training view
- show a SessionCompletionDialog after finishing regular or Moro sessions with follow-up actions for feedback or calendar navigation
- enhance phase/help screens with contextual InfoCards, video loading/error states, and expose sync feedback via a global ScaffoldMessenger listener

## Testing
- not run (flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fbcb65b9a0832d9c4bd6ea9b5da933