### PR TITLE
Fix SessionState generated constructor to include plannedFor field

### DIFF
--- a/lib/features/training/models/session_state.freezed.dart
+++ b/lib/features/training/models/session_state.freezed.dart
@@ -304,6 +304,7 @@ abstract class _SessionState implements SessionState {
       final bool isPaused,
       required final DateTime startedAt,
       final DateTime? endAt,
+      final DateTime? plannedFor,
       final SessionStatus status}) = _$SessionStateImpl;
 
   factory _SessionState.fromJson(Map<String, dynamic> json) =
@@ -323,6 +324,8 @@ abstract class _SessionState implements SessionState {
   DateTime get startedAt;
   @override
   DateTime? get endAt;
+  @override
+  DateTime? get plannedFor;
   @override
   SessionStatus get status;
 


### PR DESCRIPTION
## Summary
- ensure the generated _SessionState factory includes the plannedFor parameter
- expose the plannedFor getter on the generated _SessionState interface so it aligns with SessionState

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbd3bac990832d91807304969f295d