### PR TITLE
Fix analyzer errors in route guard and login test

### DIFF
--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:free_base/services/app_routes.dart';

--- a/test/login_dashboard_flow_test.dart
+++ b/test/login_dashboard_flow_test.dart
@@ -53,7 +53,7 @@ void main() {
   testWidgets('login success navigates through role selection to dashboard',
       (tester) async {
     final mockAuth = MockAuthService();
-    when(mockAuth.signInWithEmail(any, any))
+    when(mockAuth.signInWithEmail(any<String>(), any<String>()))
         .thenAnswer((_) async => FakeUserCredential());
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- import the Flutter widgets library to provide BuildContext in the route guard
- update the login flow widget test to use type-safe Mockito matchers for strings

## Testing
- `flutter analyze` *(fails: flutter: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbdf1665f0832d8a3ae02df7c61785