### PR TITLE
Allow calendar tab before finishing onboarding session

### DIFF
--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -65,6 +65,9 @@ class AppRouteGuard {
     if (location == AppRoutePaths.training ||
         location == AppRoutePaths.trainingCompleted ||
         location == AppRoutePaths.dashboard ||
+        // Calendar should remain reachable from the bottom navigation
+        // even before completing the onboarding session.
+        location.startsWith(AppRoutePaths.calendar) ||
         location.startsWith(AppRoutePaths.moroTraining)) {
       return false;
     }


### PR DESCRIPTION
## Summary
- allow calendar routes to bypass the "first session" guard so the Kalender tab remains reachable from the bottom navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbe2a0687c832d9f8cd635e65c614b