### PR TITLE
Implement guided Moro training flow

### DIFF
--- a/assets/moro/moro_exercises.json
+++ b/assets/moro/moro_exercises.json
@@ -1,9 +1,226 @@
 [
-  {"index":1,"title":"Moro 1","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
-  {"index":2,"title":"Moro 2","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
-  {"index":3,"title":"Moro 3","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
-  {"index":4,"title":"Moro 4","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
-  {"index":5,"title":"Moro 5","type":"phased4x","repeats":3,"phasesPerRepeat":4,"baseSeconds":3},
-  {"index":6,"title":"Moro 6","type":"simple","repeats":6,"phasesPerRepeat":1,"baseSeconds":7},
-  {"index":7,"title":"Moro 7","type":"simple","repeats":6,"phasesPerRepeat":1,"baseSeconds":7}
+  {
+    "index": 1,
+    "title": "Moro #1 – Kniependel",
+    "type": "phased4x",
+    "repeats": 3,
+    "phasesPerRepeat": 4,
+    "baseSeconds": 3,
+    "goal": "Sanfte Mobilisation der Lendenwirbelsäule und Beckenkontrolle.",
+    "startPosition": "Rückenlage mit ausgestreckten Beinen, Hände flach neben dem Körper, Augen offen.",
+    "endPosition": "Knie abwechselnd zur Seite geführt, anschließend zurück in Ausgangsposition.",
+    "steps": [
+      {"order": 1, "text": "Atme ruhig ein, lege Hände offen ab und stabilisiere den Kopf neutral."},
+      {"order": 2, "text": "Führe beide Knie in etwa drei Sekunden zur rechten Seite, Schultern bleiben am Boden.", "durationSec": 3},
+      {"order": 3, "text": "Ziehe die Knie in drei Sekunden zurück zur Mitte und wiederhole zur linken Seite.", "durationSec": 3},
+      {"order": 4, "text": "Rolle kontrolliert weiter, bis drei Wiederholungen pro Seite abgeschlossen sind."}
+    ],
+    "cues": [
+      "Lass die Bewegung weich aus dem Becken starten.",
+      "Kniescheiben zeigen nach oben, Füße entspannt.",
+      "Augen bleiben offen für Orientierung."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Lass die Ausatmung die Bewegung zurück zur Mitte begleiten."},
+    "abortRules": [
+      "Starker Schmerz in Rücken oder Hüfte",
+      "Blockade oder Widerstand im Bewegungsweg",
+      "Deutliche Asymmetrie zwischen rechts und links"
+    ],
+    "notes": "Arbeite mit kleinem Bewegungsradius, wenn die Lendenwirbelsäule empfindlich reagiert.",
+    "tags": ["mobility", "core"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  },
+  {
+    "index": 2,
+    "title": "Moro #2 – Stirn zu den Knien",
+    "type": "phased4x",
+    "repeats": 3,
+    "phasesPerRepeat": 4,
+    "baseSeconds": 3,
+    "goal": "Aktivierung der vorderen Faszienkette und Koordination der Atemspannung.",
+    "startPosition": "Rückenlage, Beine hüftbreit angewinkelt, Hände fassen nicht, sondern liegen flach neben dem Körper.",
+    "endPosition": "Oberkörper und Kopf rollen Richtung Knie, Stirn nähert sich den Knien, danach kontrolliert ablegen.",
+    "steps": [
+      {"order": 1, "text": "Bereite dich mit ruhiger Einatmung vor und entspanne Schultern und Gesicht."},
+      {"order": 2, "text": "Atme lang aus und rolle Oberkörper sowie Kopf innerhalb von drei Sekunden Richtung Knie.", "durationSec": 3},
+      {"order": 3, "text": "Halte die Position für drei Sekunden mit sanfter Bauchspannung."},
+      {"order": 4, "text": "Lege dich in drei Sekunden wieder Wirbel für Wirbel zurück auf die Matte.", "durationSec": 3}
+    ],
+    "cues": [
+      "Core weich aktiv – keine harte Pressatmung.",
+      "Nacken lang lassen, Blick zu den Knien.",
+      "Regression: Schienbeine mit den Händen umfassen, falls nötig."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Lange Ausatmung trägt dich in die Flexion."},
+    "abortRules": [
+      "Schmerz im Nacken oder Ziehen in der Halswirbelsäule",
+      "Schwindel oder starke Spannung im Bauch",
+      "Asymmetrisches Hochrollen"
+    ],
+    "notes": "Arbeite nur so hoch wie sich der Nacken wohlfühlt; Fokus auf gleichmäßige Bewegung.",
+    "tags": ["core", "stability"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  },
+  {
+    "index": 3,
+    "title": "Moro #3 – Halb-Frosch",
+    "type": "phased4x",
+    "repeats": 3,
+    "phasesPerRepeat": 4,
+    "baseSeconds": 3,
+    "goal": "Differenzierte Hüftöffnung mit Kontaktführung und Beckenstabilität.",
+    "startPosition": "Rückenlage, ein Bein ausgestreckt, anderes Bein beginnt gleitend an der Innenseite entlang.",
+    "endPosition": "Fußsohle gleitet bis zur Leiste und kehrt dann entlang des Beins zurück.",
+    "steps": [
+      {"order": 1, "text": "Lege Hände offen ab, Blick zur Decke, halte Becken zentriert."},
+      {"order": 2, "text": "Führe die Fußsohle in drei Sekunden entlang des gestreckten Beins nach oben – der Kontakt bleibt erhalten.", "durationSec": 3},
+      {"order": 3, "text": "Gleite in drei Sekunden zurück nach unten, ohne das Becken zu drehen.", "durationSec": 3},
+      {"order": 4, "text": "Wechsle kontrolliert nach jeder Wiederholung die Seite."}
+    ],
+    "cues": [
+      "Nur so weit öffnen, wie der Fuß Kontakt hält.",
+      "Becken bleibt ruhig, Lendenwirbelsäule neutral.",
+      "Schultern und Hände bleiben weich auf der Unterlage."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Ausatmung unterstützt das Zurückgleiten."},
+    "abortRules": [
+      "Blockaden im Hüftgelenk",
+      "Schmerzhaftes Ziehen an der Innenseite des Beins",
+      "Unkontrollierbare Beckenrotation"
+    ],
+    "notes": "Platziere ggf. ein Tuch unter der gleitenden Ferse für weniger Reibung.",
+    "tags": ["mobility", "hip"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  },
+  {
+    "index": 4,
+    "title": "Moro #4 – Frosch",
+    "type": "phased4x",
+    "repeats": 3,
+    "phasesPerRepeat": 4,
+    "baseSeconds": 3,
+    "goal": "Symmetrische Hüftöffnung mit Fokus auf Weichheit und Kontakt der Fußsohlen.",
+    "startPosition": "Rückenlage, Fußsohlen berühren sich, Knie fallen entspannt nach außen.",
+    "endPosition": "Fersen gleiten Richtung Becken und kehren zurück, Fußsohlen bleiben komplett in Kontakt.",
+    "steps": [
+      {"order": 1, "text": "Lege Hände offen neben dem Körper und richte Blick nach oben."},
+      {"order": 2, "text": "Ziehe die Fersen in drei Sekunden Richtung Körper, ohne den Fußkontakt zu verlieren.", "durationSec": 3},
+      {"order": 3, "text": "Lass die Beine in drei Sekunden kontrolliert wieder nach außen gleiten.", "durationSec": 3},
+      {"order": 4, "text": "Halte Schultern und Bauch entspannt, wiederhole drei Durchgänge."}
+    ],
+    "cues": [
+      "Nur so weit ziehen, wie die Fußsohlen flächig bleiben.",
+      "Atme weich in den Bauch, lass die Leisten los.",
+      "Knie hängen schwer, nicht aktiv nach unten drücken."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Ausatmung begleitet das Öffnen der Knie."},
+    "abortRules": [
+      "Stechender Schmerz in der Leiste",
+      "Taubheitsgefühl in den Oberschenkeln",
+      "Blockade im unteren Rücken"
+    ],
+    "notes": "Unterstütze die Knie bei Bedarf mit Blöcken oder Kissen.",
+    "tags": ["mobility", "hip"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  },
+  {
+    "index": 5,
+    "title": "Moro #5 – Beinauflage",
+    "type": "phased4x",
+    "repeats": 3,
+    "phasesPerRepeat": 4,
+    "baseSeconds": 3,
+    "goal": "Rotation und diagonale Streckung zur Integration der Körpermitte.",
+    "startPosition": "Rückenlage, ein Bein bleibt lang, das andere hebt zur Auflage auf dem Schienbein.",
+    "endPosition": "Aktives Bein liegt vollständig auf dem anderen Schienbein, danach zurückführen und Seite wechseln.",
+    "steps": [
+      {"order": 1, "text": "Stabilisiere Arme und Hände in der Preroll-Position, Blick zur Decke."},
+      {"order": 2, "text": "Hebe ein Bein in drei Sekunden an und führe es kontrolliert über das andere Bein.", "durationSec": 3},
+      {"order": 3, "text": "Lege den Unterschenkel vollständig ab, halte kurz Kontakt.", "durationSec": 3},
+      {"order": 4, "text": "Führe das Bein in drei Sekunden zurück und wechsle die Seite.", "durationSec": 3}
+    ],
+    "cues": [
+      "Das ruhende Bein bleibt am Boden verankert.",
+      "Hände drücken sanft in die Unterlage für Stabilität.",
+      "Augen bleiben offen und folgen der Bewegung nicht."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Ausatmung unterstützt das Zurückbringen des Beins."},
+    "abortRules": [
+      "Schmerz in Hüfte oder Knie",
+      "Gefühl von Instabilität im Becken",
+      "Schwindel beim Seitenwechsel"
+    ],
+    "notes": "Nutze einen Gurt, falls das Ablegen des Unterschenkels schwer fällt.",
+    "tags": ["mobility", "coordination"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  },
+  {
+    "index": 6,
+    "title": "Moro #6 – Druck & Gegendruck",
+    "type": "simple",
+    "repeats": 6,
+    "phasesPerRepeat": 1,
+    "baseSeconds": 7,
+    "goal": "Aufbau von Rumpfspannung über sanften Widerstand und koordinierte Atmung.",
+    "startPosition": "Rückenlage, Hände an die Knie gelegt, Beine leicht vom Körper weg, Arme gestreckt.",
+    "endPosition": "Beine drücken sanft nach vorne, Hände halten gleichmäßig dagegen, danach in Ausgangsposition lösen.",
+    "steps": [
+      {"order": 1, "text": "Bereite dich mit tiefer Einatmung vor, Hände liegen flach auf den Knien."},
+      {"order": 2, "text": "Strecke Beine sanft nach vorne und bau über sieben Sekunden Gegendruck mit den Handflächen auf.", "durationSec": 7},
+      {"order": 3, "text": "Halte die Spannung kurz, atme nach, löse für drei Sekunden.", "durationSec": 3},
+      {"order": 4, "text": "Wiederhole insgesamt sechs Runden mit ruhiger Atmung."}
+    ],
+    "cues": [
+      "Spannung gleichmäßig auf beide Seiten verteilen.",
+      "Nacken bleibt lang, Hinterkopf am Boden.",
+      "Ausatmung fließt durch den Mund, ohne Pressen."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Jede Wiederholung begleitet eine etwa sieben Sekunden lange Ausatmung."},
+    "abortRules": [
+      "Schmerz im unteren Rücken",
+      "Taubheit in Füßen oder Händen",
+      "Atemnot oder Schwindel"
+    ],
+    "notes": "Passe den Druck an – Ziel ist ein gleichmäßiger Widerstand, kein Zittern.",
+    "tags": ["stability", "core"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  },
+  {
+    "index": 7,
+    "title": "Moro #7 – Überkreuzer",
+    "type": "simple",
+    "repeats": 6,
+    "phasesPerRepeat": 1,
+    "baseSeconds": 7,
+    "goal": "Diagonale Spannung und Ganzkörperintegration durch gekreuzten Gegendruck.",
+    "startPosition": "Rückenlage, Arme überkreuzen auf den Oberschenkeln, Kopf leicht zur Brust geneigt.",
+    "endPosition": "Beine ziehen Richtung Körper, Arme arbeiten diagonal dagegen, nach drei Durchgängen Armkreuz wechseln.",
+    "steps": [
+      {"order": 1, "text": "Leg die Arme überkreuz auf Oberschenkel und finde eine lange Halswirbelsäule."},
+      {"order": 2, "text": "Zieh die Beine mit der Ausatmung für sieben Sekunden zum Körper, Hände halten gleichmäßig dagegen.", "durationSec": 7},
+      {"order": 3, "text": "Halte drei Sekunden Pause, lass Schultern sinken und atme nach.", "durationSec": 3},
+      {"order": 4, "text": "Nach drei Wiederholungen Arme neu kreuzen und Richtung wechseln."}
+    ],
+    "cues": [
+      "Kopf bleibt leicht zur Brust geneigt, Blick weich nach vorne.",
+      "Zieh gleichmäßig aus beiden Beinen, ohne zu ruckeln.",
+      "Spür die diagonale Verbindung zwischen Händen und Rumpf."
+    ],
+    "breath": {"pattern": "emphasis-exhale", "exhaleSec": 7, "notes": "Jeder Zug nach innen begleitet eine lange Ausatmung mit anschließendem kurzen Innehalten."},
+    "abortRules": [
+      "Nackenschmerz oder Kopfdruck",
+      "Asymmetrische Kraftentwicklung",
+      "Atemnot oder Schwindel"
+    ],
+    "notes": "Unterstütze den Kopf bei Bedarf mit einem kleinen Kissen.",
+    "tags": ["stability", "coordination"],
+    "version": "1.0.0",
+    "media": {"image": "assets/images/placeholder.png"}
+  }
 ]

--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'moro_log_store.dart';
 import 'moro_models.dart';
 import 'timers.dart';
 
@@ -18,12 +19,26 @@ class MoroExerciseScreenArgs {
 class MoroExerciseResult {
   final bool completed;
   final Duration? duration;
+  final int? tension;
+  final int? pain;
+  final String? notes;
 
   const MoroExerciseResult({
     required this.completed,
     this.duration,
+    this.tension,
+    this.pain,
+    this.notes,
   });
 }
+
+enum _MoroStage { preroll, setup, play, cooldown, log }
+
+const _prerollChecklist = [
+  'Beine parallel, nicht überkreuzen',
+  'Handflächen flach/offen auflegen',
+  'Augen offen',
+];
 
 class MoroExerciseScreen extends StatefulWidget {
   final MoroExercise exercise;
@@ -40,20 +55,54 @@ class MoroExerciseScreen extends StatefulWidget {
 }
 
 class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
-  late final CancelToken _cancelToken;
+  final Map<int, bool> _checkStates = {
+    for (var i = 0; i < _prerollChecklist.length; i++) i: false,
+  };
+  _MoroStage _stage = _MoroStage.preroll;
+  bool _matReady = false;
+  bool _timerSound = true;
+  bool _musicOff = true;
   StreamSubscription? _subscription;
+  late final CancelToken _cancelToken;
+  bool _timerStarted = false;
   int _repeat = 1;
   int _phase = 1;
   Duration _remaining = Duration.zero;
+  Duration? _sessionDuration;
+  bool _completed = false;
+  final TextEditingController _notesController = TextEditingController();
+  double _tensionValue = 5;
+  double _painValue = 1;
 
   @override
   void initState() {
     super.initState();
     _cancelToken = CancelToken();
-    _startTimer();
   }
 
-  void _startTimer() {
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _cancelToken.cancel();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<bool> _handleWillPop() async {
+    _cancelTimer();
+    Navigator.of(context).pop(const MoroExerciseResult(completed: false));
+    return false;
+  }
+
+  void _cancelTimer() {
+    _subscription?.cancel();
+    _subscription = null;
+    _cancelToken.cancel();
+  }
+
+  void _startTimerIfNeeded() {
+    if (_timerStarted || _completed) return;
+    _timerStarted = true;
     final ex = widget.exercise;
     if (ex.type == MoroExerciseType.phased4x) {
       final timer = PhasedMoroTimer(
@@ -62,6 +111,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         phaseSeconds: ex.baseSeconds + widget.offset,
       );
       final totalDuration = timer.totalDuration;
+      _sessionDuration = totalDuration;
       _subscription = timer.run(_cancelToken).listen((event) {
         if (!mounted) return;
         setState(() {
@@ -70,12 +120,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
           _remaining = event.remaining;
         });
         if (event.done && mounted) {
-          Navigator.of(context).maybePop(
-            MoroExerciseResult(
-              completed: true,
-              duration: totalDuration,
-            ),
-          );
+          _onTimerCompleted(totalDuration);
         }
       });
     } else {
@@ -84,6 +129,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         repeatSeconds: ex.baseSeconds + widget.offset,
       );
       final totalDuration = timer.totalDuration;
+      _sessionDuration = totalDuration;
       _subscription = timer.run(_cancelToken).listen((event) {
         if (!mounted) return;
         setState(() {
@@ -92,15 +138,19 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
           _remaining = event.remaining;
         });
         if (event.done && mounted) {
-          Navigator.of(context).maybePop(
-            MoroExerciseResult(
-              completed: true,
-              duration: totalDuration,
-            ),
-          );
+          _onTimerCompleted(totalDuration);
         }
       });
     }
+  }
+
+  void _onTimerCompleted(Duration total) {
+    _cancelTimer();
+    setState(() {
+      _completed = true;
+      _stage = _MoroStage.cooldown;
+      _sessionDuration = total;
+    });
   }
 
   double _segmentProgress() {
@@ -112,26 +162,325 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
     return 1 - remainingMs / (totalSeconds * 1000);
   }
 
-  Future<bool> _handleWillPop() async {
-    _cancelToken.cancel();
-    Navigator.of(context).pop(const MoroExerciseResult(completed: false));
-    return false;
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes;
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return minutes > 0 ? '$minutes:$seconds min' : '$seconds s';
   }
 
-  @override
-  void dispose() {
-    _subscription?.cancel();
-    _cancelToken.cancel();
-    super.dispose();
+  Widget _buildStageContent() {
+    switch (_stage) {
+      case _MoroStage.preroll:
+        return _buildPreroll();
+      case _MoroStage.setup:
+        return _buildSetup();
+      case _MoroStage.play:
+        _startTimerIfNeeded();
+        return _buildPlayer();
+      case _MoroStage.cooldown:
+        return _buildCooldown();
+      case _MoroStage.log:
+        return _buildLog();
+    }
+  }
+
+  Widget _buildPreroll() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Preroll Check', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 12),
+        ..._prerollChecklist.asMap().entries.map((entry) {
+          final idx = entry.key;
+          final label = entry.value;
+          return CheckboxListTile(
+            value: _checkStates[idx],
+            onChanged: (v) => setState(() => _checkStates[idx] = v ?? false),
+            title: Text(label),
+          );
+        }),
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _checkStates.values.every((v) => v)
+                ? () => setState(() => _stage = _MoroStage.setup)
+                : null,
+            child: const Text('Weiter zu Setup'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSetup() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Setup', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 12),
+        SwitchListTile(
+          value: _matReady,
+          onChanged: (v) => setState(() => _matReady = v),
+          title: const Text('Matte bereitgelegt'),
+        ),
+        SwitchListTile(
+          value: _timerSound,
+          onChanged: (v) => setState(() => _timerSound = v),
+          title: const Text('Timer-Sound aktiv'),
+        ),
+        SwitchListTile(
+          value: _musicOff,
+          onChanged: (v) => setState(() => _musicOff = v),
+          title: const Text('Musik aus / Fokusmodus'),
+        ),
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _matReady && _timerSound && _musicOff
+                ? () => setState(() => _stage = _MoroStage.play)
+                : null,
+            child: const Text('Session starten'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPlayer() {
+    final ex = widget.exercise;
+    final phaseInfo = ex.type == MoroExerciseType.phased4x
+        ? 'Phase: $_phase / ${ex.phasesPerRepeat}'
+        : 'Aktive Wiederholung';
+    final totalRepeats = ex.repeats;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Übung ${ex.index}', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Text(ex.goal),
+        const SizedBox(height: 12),
+        LinearProgressIndicator(value: _segmentProgress().clamp(0.0, 1.0)),
+        const SizedBox(height: 8),
+        Text('Wiederholung: $_repeat / $totalRepeats'),
+        Text(phaseInfo),
+        const SizedBox(height: 12),
+        Text('Restzeit aktuelle Phase: ${_remaining.inSeconds}s'),
+        const SizedBox(height: 16),
+        Text('Schritte', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildDefinitionTile('Startposition', ex.startPosition),
+                if (ex.endPosition != null && ex.endPosition!.isNotEmpty)
+                  _buildDefinitionTile('Endposition', ex.endPosition!),
+                _buildDefinitionTile(
+                  'Atmung',
+                  _describeBreath(ex.breath),
+                ),
+                const SizedBox(height: 12),
+                ...ex.steps.map((step) => ListTile(
+                      dense: true,
+                      leading: CircleAvatar(
+                        radius: 14,
+                        child: Text('${step.order}'),
+                      ),
+                      title: Text(step.text),
+                      subtitle: step.durationSec != null
+                          ? Text('${step.durationSec}s')
+                          : null,
+                    )),
+                const SizedBox(height: 12),
+                Text('Cues', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                ...ex.cues.map((cue) => ListTile(
+                      dense: true,
+                      leading: const Icon(Icons.check_circle_outline),
+                      title: Text(cue),
+                    )),
+                const SizedBox(height: 12),
+                Text('Abort-Kriterien', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                ...ex.abortRules.map((rule) => ListTile(
+                      dense: true,
+                      leading: const Icon(Icons.warning_amber_outlined),
+                      title: Text(rule),
+                    )),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton(
+            onPressed: () {
+              _cancelTimer();
+              Navigator.of(context)
+                  .maybePop(const MoroExerciseResult(completed: false));
+            },
+            child: const Text('Abbrechen'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCooldown() {
+    final duration = _sessionDuration ?? const Duration();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Cooldown', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 12),
+        ListTile(
+          leading: const Icon(Icons.timer_outlined),
+          title: const Text('Gesamtdauer'),
+          subtitle: Text(_formatDuration(duration)),
+        ),
+        ListTile(
+          leading: const Icon(Icons.check_circle_outline),
+          title: const Text('Status'),
+          subtitle: Text(_completed ? 'Abgeschlossen' : 'Nicht abgeschlossen'),
+        ),
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _completed
+                ? () => setState(() => _stage = _MoroStage.log)
+                : () => Navigator.of(context)
+                    .maybePop(const MoroExerciseResult(completed: false)),
+            child: Text(_completed ? 'Zum Protokoll' : 'Zurück zur Übersicht'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLog() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Session-Log', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 16),
+        _buildSlider(
+          label: 'Spannung',
+          value: _tensionValue,
+          onChanged: (v) => setState(() => _tensionValue = v),
+        ),
+        _buildSlider(
+          label: 'Schmerz',
+          value: _painValue,
+          onChanged: (v) => setState(() => _painValue = v),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _notesController,
+          maxLines: 4,
+          decoration: const InputDecoration(
+            labelText: 'Notizen',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _saveLogAndClose,
+            child: const Text('Speichern & schließen'),
+          ),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).maybePop(MoroExerciseResult(
+              completed: true,
+              duration: _sessionDuration,
+            ));
+          },
+          child: const Text('Ohne Log schließen'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSlider({
+    required String label,
+    required double value,
+    required ValueChanged<double> onChanged,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: Theme.of(context).textTheme.titleMedium),
+        Slider(
+          value: value,
+          min: 1,
+          max: 10,
+          divisions: 9,
+          label: value.round().toString(),
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDefinitionTile(String title, String body) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 4),
+          Text(body),
+        ],
+      ),
+    );
+  }
+
+  String _describeBreath(MoroBreathPattern pattern) {
+    final buffer = StringBuffer();
+    buffer.write(pattern.pattern);
+    if (pattern.exhaleSec != null) {
+      buffer.write(' · Ausatmung ca. ${pattern.exhaleSec}s');
+    }
+    if (pattern.holdSec != null) {
+      buffer.write(' · Halten ${pattern.holdSec}s');
+    }
+    if (pattern.notes != null && pattern.notes!.isNotEmpty) {
+      buffer.write(' — ${pattern.notes}');
+    }
+    return buffer.toString();
+  }
+
+  Future<void> _saveLogAndClose() async {
+    final entry = MoroLogEntry(
+      timestamp: DateTime.now(),
+      exerciseIndex: widget.exercise.index,
+      tension: _tensionValue.round(),
+      pain: _painValue.round(),
+      notes: _notesController.text.isNotEmpty ? _notesController.text : null,
+    );
+    await MoroLogStore.addEntry(entry);
+    if (!mounted) return;
+    Navigator.of(context).maybePop(MoroExerciseResult(
+      completed: true,
+      duration: _sessionDuration,
+      tension: entry.tension,
+      pain: entry.pain,
+      notes: entry.notes,
+    ));
   }
 
   @override
   Widget build(BuildContext context) {
     final ex = widget.exercise;
-    final phaseInfo = ex.type == MoroExerciseType.phased4x
-        ? 'Phase: $_phase / ${ex.phasesPerRepeat}'
-        : 'Aktive Wiederholung';
-
     return WillPopScope(
       onWillPop: _handleWillPop,
       child: Scaffold(
@@ -140,7 +489,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
           leading: IconButton(
             icon: const Icon(Icons.close),
             onPressed: () {
-              _cancelToken.cancel();
+              _cancelTimer();
               Navigator.of(context)
                   .maybePop(const MoroExerciseResult(completed: false));
             },
@@ -148,32 +497,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         ),
         body: Padding(
           padding: const EdgeInsets.all(24.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Übung ${ex.index}', style: Theme.of(context).textTheme.titleMedium),
-              const SizedBox(height: 12),
-              Text('Wiederholung: $_repeat / ${ex.repeats}'),
-              const SizedBox(height: 4),
-              Text(phaseInfo),
-              const SizedBox(height: 24),
-              LinearProgressIndicator(value: _segmentProgress().clamp(0.0, 1.0)),
-              const SizedBox(height: 12),
-              Text('Restzeit: ${_remaining.inSeconds}s'),
-              const Spacer(),
-              SizedBox(
-                width: double.infinity,
-                child: OutlinedButton(
-                  onPressed: () {
-                    _cancelToken.cancel();
-                    Navigator.of(context)
-                        .maybePop(const MoroExerciseResult(completed: false));
-                  },
-                  child: const Text('Abbrechen'),
-                ),
-              ),
-            ],
-          ),
+          child: _buildStageContent(),
         ),
       ),
     );

--- a/lib/features/training/moro/moro_log_store.dart
+++ b/lib/features/training/moro/moro_log_store.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:hive/hive.dart';
+
+class MoroLogEntry {
+  final DateTime timestamp;
+  final int exerciseIndex;
+  final int tension;
+  final int pain;
+  final String? notes;
+
+  const MoroLogEntry({
+    required this.timestamp,
+    required this.exerciseIndex,
+    required this.tension,
+    required this.pain,
+    this.notes,
+  });
+}
+
+class MoroLogStore {
+  static const _boxName = 'moro_logs';
+  static const _entriesKey = 'entries';
+
+  static Future<void> addEntry(MoroLogEntry entry) async {
+    final box = await Hive.openBox(_boxName);
+    final raw = box.get(_entriesKey) as String?;
+    final list = <Map<String, dynamic>>[];
+    if (raw != null) {
+      try {
+        final parsed = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
+        list.addAll(parsed);
+      } catch (_) {
+        list.clear();
+      }
+    }
+    list.add({
+      'timestamp': entry.timestamp.toIso8601String(),
+      'exerciseIndex': entry.exerciseIndex,
+      'tension': entry.tension,
+      'pain': entry.pain,
+      'notes': entry.notes,
+    });
+    await box.put(_entriesKey, jsonEncode(list));
+  }
+
+  static Future<List<MoroLogEntry>> loadEntries({int? exerciseIndex}) async {
+    final box = await Hive.openBox(_boxName);
+    final raw = box.get(_entriesKey) as String?;
+    if (raw == null) return const [];
+    try {
+      final parsed = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
+      final entries = parsed.map((e) {
+        return MoroLogEntry(
+          timestamp: DateTime.tryParse(e['timestamp'] as String? ?? '') ?? DateTime.now(),
+          exerciseIndex: e['exerciseIndex'] as int? ?? 0,
+          tension: e['tension'] as int? ?? 0,
+          pain: e['pain'] as int? ?? 0,
+          notes: e['notes'] as String?,
+        );
+      });
+      if (exerciseIndex != null) {
+        return entries
+            .where((entry) => entry.exerciseIndex == exerciseIndex)
+            .toList(growable: false);
+      }
+      return entries.toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
+  }
+}

--- a/lib/features/training/moro/moro_models.dart
+++ b/lib/features/training/moro/moro_models.dart
@@ -1,12 +1,59 @@
 enum MoroExerciseType { phased4x, simple }
 
+class MoroExerciseStep {
+  final int order;
+  final String text;
+  final int? durationSec;
+
+  const MoroExerciseStep({
+    required this.order,
+    required this.text,
+    this.durationSec,
+  });
+}
+
+class MoroBreathPattern {
+  final String pattern;
+  final int? exhaleSec;
+  final int? holdSec;
+  final String? notes;
+
+  const MoroBreathPattern({
+    required this.pattern,
+    this.exhaleSec,
+    this.holdSec,
+    this.notes,
+  });
+}
+
+class MoroMedia {
+  final String? image;
+  final String? video;
+
+  const MoroMedia({
+    this.image,
+    this.video,
+  });
+}
+
 class MoroExercise {
   final int index; // 1..7
   final String title;
   final MoroExerciseType type;
-  final int repeats;           // 1-5: 3 ; 6-7: 6
-  final int phasesPerRepeat;   // 1-5: 4 ; 6-7: 1
-  final int baseSeconds;       // 1-5: 3 (per phase) ; 6-7: 7 (per repeat)
+  final int repeats; // 1-5: 3 ; 6-7: 6
+  final int phasesPerRepeat; // 1-5: 4 ; 6-7: 1
+  final int baseSeconds; // 1-5: 3 (per phase) ; 6-7: 7 (per repeat)
+  final String goal;
+  final String startPosition;
+  final String? endPosition;
+  final List<MoroExerciseStep> steps;
+  final List<String> cues;
+  final MoroBreathPattern breath;
+  final List<String> abortRules;
+  final String? notes;
+  final List<String> tags;
+  final String version;
+  final MoroMedia media;
 
   const MoroExercise({
     required this.index,
@@ -15,5 +62,16 @@ class MoroExercise {
     required this.repeats,
     required this.phasesPerRepeat,
     required this.baseSeconds,
+    required this.goal,
+    required this.startPosition,
+    this.endPosition,
+    required this.steps,
+    required this.cues,
+    required this.breath,
+    required this.abortRules,
+    this.notes,
+    required this.tags,
+    required this.version,
+    required this.media,
   });
 }

--- a/lib/features/training/moro/moro_progress_store.dart
+++ b/lib/features/training/moro/moro_progress_store.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+
+import 'package:hive/hive.dart';
+
+class MoroProgressData {
+  final int highestUnlocked;
+  final Set<int> completed;
+
+  const MoroProgressData({
+    required this.highestUnlocked,
+    required this.completed,
+  });
+}
+
+class MoroProgressStore {
+  static const _boxName = 'moro_progress';
+  static const _progressKey = 'progress';
+
+  static Future<MoroProgressData> load({int totalExercises = 7}) async {
+    final box = await Hive.openBox(_boxName);
+    final raw = box.get(_progressKey) as String?;
+    if (raw == null) {
+      return MoroProgressData(highestUnlocked: 1, completed: <int>{});
+    }
+    try {
+      final map = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      final highest = map['highestUnlocked'] as int? ?? 1;
+      final completed = ((map['completed'] as List?) ?? const [])
+          .map((e) => e as int)
+          .where((idx) => idx >= 1 && idx <= totalExercises)
+          .toSet();
+      final unlocked = highest.clamp(1, totalExercises);
+      return MoroProgressData(highestUnlocked: unlocked, completed: completed);
+    } catch (_) {
+      return MoroProgressData(highestUnlocked: 1, completed: <int>{});
+    }
+  }
+
+  static Future<void> reset() async {
+    final box = await Hive.openBox(_boxName);
+    await box.delete(_progressKey);
+  }
+
+  static Future<void> markCompleted(int exerciseIndex, int totalExercises) async {
+    final box = await Hive.openBox(_boxName);
+    final current = await load(totalExercises: totalExercises);
+    final completed = {...current.completed, exerciseIndex};
+    final nextUnlocked = (exerciseIndex + 1).clamp(1, totalExercises);
+    final highest = current.highestUnlocked < nextUnlocked
+        ? nextUnlocked
+        : current.highestUnlocked;
+    final payload = jsonEncode({
+      'highestUnlocked': highest,
+      'completed': completed.toList(),
+    });
+    await box.put(_progressKey, payload);
+  }
+}

--- a/lib/features/training/moro/moro_repository.dart
+++ b/lib/features/training/moro/moro_repository.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+
 import 'package:flutter/services.dart' show rootBundle;
+
 import 'moro_models.dart';
 
 class MoroRepository {
@@ -10,6 +12,35 @@ class MoroRepository {
       final type = e['type'] == 'phased4x'
           ? MoroExerciseType.phased4x
           : MoroExerciseType.simple;
+      final stepsRaw = (e['steps'] as List?) ?? const [];
+      final steps = stepsRaw
+          .map((step) => MoroExerciseStep(
+                order: step['order'] as int? ?? 0,
+                text: step['text'] as String? ?? '',
+                durationSec: step['durationSec'] as int?,
+              ))
+          .toList();
+      final cues = ((e['cues'] as List?) ?? const [])
+          .map((c) => c.toString())
+          .toList();
+      final breathRaw = (e['breath'] as Map?)?.cast<String, dynamic>();
+      final breath = MoroBreathPattern(
+        pattern: breathRaw?['pattern'] as String? ?? 'emphasis-exhale',
+        exhaleSec: breathRaw?['exhaleSec'] as int?,
+        holdSec: breathRaw?['holdSec'] as int?,
+        notes: breathRaw?['notes'] as String?,
+      );
+      final abortRules = ((e['abortRules'] as List?) ?? const [])
+          .map((a) => a.toString())
+          .toList();
+      final tags = ((e['tags'] as List?) ?? const [])
+          .map((t) => t.toString())
+          .toList();
+      final mediaRaw = (e['media'] as Map?)?.cast<String, dynamic>() ?? {};
+      final media = MoroMedia(
+        image: mediaRaw['image'] as String?,
+        video: mediaRaw['video'] as String?,
+      );
       return MoroExercise(
         index: e['index'] as int,
         title: e['title'] as String,
@@ -17,6 +48,17 @@ class MoroRepository {
         repeats: e['repeats'] as int,
         phasesPerRepeat: e['phasesPerRepeat'] as int,
         baseSeconds: e['baseSeconds'] as int,
+        goal: e['goal'] as String? ?? '',
+        startPosition: e['startPosition'] as String? ?? '',
+        endPosition: e['endPosition'] as String?,
+        steps: steps,
+        cues: cues,
+        breath: breath,
+        abortRules: abortRules,
+        notes: e['notes'] as String?,
+        tags: tags,
+        version: e['version'] as String? ?? '1.0.0',
+        media: media,
       );
     }).toList();
     items.sort((a, b) => a.index.compareTo(b.index));

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -6,6 +6,7 @@ import 'package:free_base/services/app_routes.dart';
 
 import 'moro_exercise_screen.dart';
 import 'moro_models.dart';
+import 'moro_progress_store.dart';
 import 'moro_repository.dart';
 import 'moro_speed_store.dart';
 
@@ -18,11 +19,13 @@ class MoroTrainingScreen extends StatefulWidget {
 class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
   late Future<List<MoroExercise>> _future;
   final Map<int, int> _offsets = {}; // exerciseIndex -> offset (0..3)
+  Future<MoroProgressData>? _progressFuture;
 
   @override
   void initState() {
     super.initState();
     _future = MoroRepository().load();
+    _progressFuture = MoroProgressStore.load();
   }
 
   Future<int> _getOffset(int idx) async {
@@ -35,6 +38,14 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
   Future<void> _setOffset(int idx, int v) async {
     await MoroSpeedStore.setOffsetForExercise(idx, v);
     setState(() => _offsets[idx] = v);
+  }
+
+  Future<void> _refreshProgress(int total) async {
+    final data = await MoroProgressStore.load(totalExercises: total);
+    if (!mounted) return;
+    setState(() {
+      _progressFuture = Future.value(data);
+    });
   }
 
   @override
@@ -51,34 +62,127 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
             return Center(child: Text('Fehler beim Laden: ${snap.error}'));
           }
           final items = snap.data ?? const <MoroExercise>[];
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: items.map((ex) {
-              return FutureBuilder<int>(
-                future: _getOffset(ex.index),
-                builder: (context, ofsSnap) {
-                  final offs = ofsSnap.data ?? 0;
-                  final subtitle = ex.type == MoroExerciseType.phased4x
-                      ? '3 Wdh · 4 Phasen × ${(ex.baseSeconds + offs)}s · Pause 3s'
-                      : '6 Wdh · ${(ex.baseSeconds + offs)}s je Wdh · Pause 3s';
+          if (_progressFuture == null) {
+            _progressFuture = MoroProgressStore.load(totalExercises: items.length);
+          }
+          return FutureBuilder<MoroProgressData>(
+            future: _progressFuture,
+            builder: (context, progressSnap) {
+              if (!progressSnap.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final progress = progressSnap.data!;
+              return RefreshIndicator(
+                onRefresh: () => _refreshProgress(items.length),
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(16),
+                  children: items.map((ex) {
+                    final isUnlocked = ex.index <= progress.highestUnlocked;
+                    final isCompleted = progress.completed.contains(ex.index);
+                    final lockLabel = isUnlocked
+                        ? (isCompleted ? 'Abgeschlossen' : 'Bereit')
+                        : 'Gesperrt';
+                    final MaterialColor lockColor = isUnlocked
+                        ? (isCompleted ? Colors.green : Colors.blue)
+                        : Colors.grey;
+                    final Color labelColor = isUnlocked
+                        ? (isCompleted
+                            ? Colors.green.shade700
+                            : Colors.blue.shade700)
+                        : Colors.grey.shade700;
+                    return FutureBuilder<int>(
+                      future: _getOffset(ex.index),
+                      builder: (context, ofsSnap) {
+                        final offs = ofsSnap.data ?? 0;
+                        final subtitle = ex.type == MoroExerciseType.phased4x
+                            ? '3 Durchgänge · ${ex.phasesPerRepeat} Phasen × ${(ex.baseSeconds + offs)}s · Pause 3s'
+                            : '6 Wiederholungen · ${(ex.baseSeconds + offs)}s Aktivität · Pause 3s';
 
-                  return Card(
-                    child: ListTile(
-                      title: Text('${ex.index}. ${ex.title}'),
-                      subtitle: Text(subtitle),
-                      leading: _SpeedChips(
-                        value: offs,
-                        onChanged: (v) => _setOffset(ex.index, v),
-                      ),
-                      trailing: ElevatedButton(
-                        onPressed: () => _openExercise(context, ex, offs),
-                        child: const Text('Start'),
-                      ),
-                    ),
-                  );
-                },
+                        return Card(
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 8,
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Expanded(
+                                      child: Text(
+                                        '${ex.index}. ${ex.title}',
+                                        style: Theme.of(context).textTheme.titleMedium,
+                                      ),
+                                    ),
+                                    Chip(
+                                      label: Text(lockLabel),
+                                      backgroundColor: lockColor.withOpacity(0.1),
+                                      labelStyle: TextStyle(color: labelColor),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 4),
+                                Text(ex.goal),
+                                const SizedBox(height: 4),
+                                Text(
+                                  subtitle,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .bodySmall
+                                      ?.copyWith(color: Colors.grey.shade700),
+                                ),
+                                const SizedBox(height: 8),
+                                Wrap(
+                                  spacing: 6,
+                                  runSpacing: -6,
+                                  children: ex.tags
+                                      .map(
+                                        (tag) => Chip(
+                                          label: Text(tag),
+                                          visualDensity: VisualDensity.compact,
+                                        ),
+                                      )
+                                      .toList(),
+                                ),
+                                const SizedBox(height: 8),
+                                if (ex.notes != null && ex.notes!.isNotEmpty) ...[
+                                  Text(
+                                    ex.notes!,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodySmall
+                                        ?.copyWith(color: Colors.grey.shade600),
+                                  ),
+                                  const SizedBox(height: 8),
+                                ],
+                                Row(
+                                  children: [
+                                    _SpeedChips(
+                                      value: offs,
+                                      onChanged: isUnlocked ? (v) => _setOffset(ex.index, v) : null,
+                                    ),
+                                    const Spacer(),
+                                    ElevatedButton.icon(
+                                      onPressed: isUnlocked
+                                          ? () => _openExercise(context, ex, offs, items.length)
+                                          : null,
+                                      icon: const Icon(Icons.play_arrow),
+                                      label: const Text('Start'),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    );
+                  }).toList(),
+                ),
               );
-            }).toList(),
+            },
           );
         },
       ),
@@ -89,6 +193,7 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     BuildContext context,
     MoroExercise ex,
     int offset,
+    int totalExercises,
   ) async {
     final result = await context.pushNamed(
       AppRouteNames.moroExercise,
@@ -100,6 +205,8 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     );
     if (!mounted) return;
     if (result is MoroExerciseResult && result.completed) {
+      await MoroProgressStore.markCompleted(ex.index, totalExercises);
+      await _refreshProgress(totalExercises);
       final summary = SessionCompletionSummary(
         totalDuration: result.duration ?? const Duration(),
         totalExercises: 1,
@@ -130,8 +237,8 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
 
 class _SpeedChips extends StatelessWidget {
   final int value; // 0..3
-  final ValueChanged<int> onChanged;
-  const _SpeedChips({required this.value, required this.onChanged});
+  final ValueChanged<int>? onChanged;
+  const _SpeedChips({required this.value, this.onChanged});
 
   @override
   Widget build(BuildContext context) {
@@ -149,7 +256,7 @@ class _SpeedChips extends StatelessWidget {
             return ChoiceChip(
               label: Text(v == 0 ? 'Std' : '+${v}s'),
               selected: v == value,
-              onSelected: (_) => onChanged(v),
+              onSelected: onChanged == null ? null : (_) => onChanged!(v),
             );
           }).toList(),
         ),


### PR DESCRIPTION
## Summary
- enrich the Moro exercise catalogue with structured goals, cues, breath patterns, and safety details
- persist Moro progression and logging data so only the next exercise unlocks after completion
- redesign the Moro training screens with a guided preroll/setup/player/log flow and updated UI feedback

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fcfd61ec48832d9e5eb49f8f6a9f71