### PR TITLE
Route training to Moro trainer

### DIFF
--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -67,8 +67,7 @@ class AppRouteGuard {
         location == AppRoutePaths.dashboard ||
         // Calendar should remain reachable from the bottom navigation
         // even before completing the onboarding session.
-        location.startsWith(AppRoutePaths.calendar) ||
-        location.startsWith(AppRoutePaths.moroTraining)) {
+        location.startsWith(AppRoutePaths.calendar)) {
       return false;
     }
     if (location.startsWith(AppRoutePaths.training)) {

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -21,9 +21,7 @@ import 'package:free_base/features/questionnaire/quiz_intro_screen.dart';
 import 'package:free_base/features/training/moro/moro_exercise_screen.dart';
 import 'package:free_base/features/training/moro/moro_training_screen.dart';
 import 'package:free_base/features/training/training_completed_screen.dart';
-import 'package:free_base/features/training/training_screen.dart';
 import 'package:free_base/services/app_route_guard.dart';
-import 'package:free_base/services/training_intent.dart';
 import 'package:free_base/services/app_shell.dart';
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/feature_flags.dart';
@@ -141,22 +139,7 @@ class AppRouter {
               GoRoute(
                 path: AppRoutePaths.training,
                 name: AppRouteNames.training,
-                builder: (context, state) {
-                  final extra = state.extra;
-                  TrainingIntent? intent;
-                  if (extra is TrainingIntent) {
-                    intent = extra;
-                  } else {
-                    final start = state.uri.queryParameters['start'];
-                    final resumeId = state.uri.queryParameters['sessionId'];
-                    if (start == 'true') {
-                      intent = TrainingIntent.start();
-                    } else if (resumeId != null && resumeId.isNotEmpty) {
-                      intent = TrainingIntent.resume(resumeId);
-                    }
-                  }
-                  return TrainingScreen(intent: intent);
-                },
+                builder: (context, state) => const MoroTrainingScreen(),
                 routes: [
                   GoRoute(
                     path: 'completed',
@@ -164,27 +147,20 @@ class AppRouter {
                     builder: (context, state) => const TrainingCompletedScreen(),
                   ),
                   GoRoute(
-                    path: 'moro',
-                    name: AppRouteNames.moroTraining,
-                    builder: (context, state) => const MoroTrainingScreen(),
-                    routes: [
-                      GoRoute(
-                        path: ':exerciseId',
-                        name: AppRouteNames.moroExercise,
-                        builder: (context, state) {
-                          final args = state.extra;
-                          if (args is MoroExerciseScreenArgs) {
-                            return MoroExerciseScreen(
-                              exercise: args.exercise,
-                              offset: args.offset,
-                            );
-                          }
-                          return const ErrorScreen(
-                            message: 'Ungültige Trainingsparameter.',
-                          );
-                        },
-                      ),
-                    ],
+                    path: 'moro/:exerciseId',
+                    name: AppRouteNames.moroExercise,
+                    builder: (context, state) {
+                      final args = state.extra;
+                      if (args is MoroExerciseScreenArgs) {
+                        return MoroExerciseScreen(
+                          exercise: args.exercise,
+                          offset: args.offset,
+                        );
+                      }
+                      return const ErrorScreen(
+                        message: 'Ungültige Trainingsparameter.',
+                      );
+                    },
                   ),
                 ],
               ),

--- a/lib/services/app_routes.dart
+++ b/lib/services/app_routes.dart
@@ -12,7 +12,6 @@ class AppRoutePaths {
   static const questionnaire = '/questionnaire/questions';
   static const questionnaireResult = '/questionnaire/result';
   static const trainingCompleted = '/training/completed';
-  static const moroTraining = '/training/moro';
   static const moroExercise = '/training/moro/:exerciseId';
   static const forum = '/forum';
   static const achievements = '/achievements';
@@ -26,7 +25,6 @@ class AppRouteNames {
   static const dashboard = 'dashboard';
   static const training = 'training';
   static const trainingCompleted = 'trainingCompleted';
-  static const moroTraining = 'moroTraining';
   static const moroExercise = 'moroExercise';
   static const calendar = 'calendar';
   static const profile = 'profile';


### PR DESCRIPTION
## Summary
- route the training tab directly to the Moro trainer experience
- adjust nested Moro exercise routing now that the main training path hosts the new screen
- simplify the guarded route exceptions to match the updated training paths

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fd0dd31d78832d85d7453421bd4232