### PR TITLE
Add consent routing foundations and telemetry instrumentation

### DIFF
--- a/lib/features/common/splash_screen.dart
+++ b/lib/features/common/splash_screen.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
 import 'package:free_base/features/onboarding/services/secure_storage_service.dart';
+import 'package:free_base/features/onboarding/state/consent_notifier.dart';
+import 'package:free_base/features/training/services/session_repository.dart';
 import 'package:free_base/services/app_routes.dart';
 
 /// SplashScreen: Prüft verschlüsselten Login-Status + Firebase-Auth
@@ -28,6 +32,22 @@ class _SplashScreenState extends State<SplashScreen> {
     if (!mounted) return;
 
     if (firebaseUser != null && cachedLogin) {
+      final consentNotifier = context.read<ConsentNotifier>();
+      if (!consentNotifier.hasAccepted) {
+        context.goNamed(AppRouteNames.consent);
+        return;
+      }
+
+      final sessionRepository = context.read<SessionRepository>();
+      final sessionState = await sessionRepository.load();
+      if (!mounted) return;
+
+      final onboardingComplete = sessionState?.onboardingComplete ?? false;
+      if (!onboardingComplete) {
+        context.goNamed(AppRouteNames.training);
+        return;
+      }
+
       context.goNamed(AppRouteNames.dashboard);
     } else {
       context.goNamed(AppRouteNames.login);

--- a/lib/features/onboarding/models/consent_state.dart
+++ b/lib/features/onboarding/models/consent_state.dart
@@ -1,0 +1,60 @@
+import 'package:hive/hive.dart';
+
+/// Persists the consent acceptance state for the current device/user.
+///
+/// The values are stored in the encrypted `user_settings` Hive box so they
+/// survive offline sessions and can be evaluated during routing guards.
+class ConsentState {
+  static const hiveTypeId = 3;
+
+  final bool accepted;
+  final DateTime? acceptedAt;
+  final String locale;
+
+  const ConsentState({
+    required this.accepted,
+    this.acceptedAt,
+    required this.locale,
+  });
+
+  ConsentState copyWith({
+    bool? accepted,
+    DateTime? acceptedAt,
+    String? locale,
+  }) {
+    return ConsentState(
+      accepted: accepted ?? this.accepted,
+      acceptedAt: acceptedAt ?? this.acceptedAt,
+      locale: locale ?? this.locale,
+    );
+  }
+}
+
+class ConsentStateAdapter extends TypeAdapter<ConsentState> {
+  @override
+  final int typeId = ConsentState.hiveTypeId;
+
+  @override
+  ConsentState read(BinaryReader reader) {
+    final accepted = reader.readBool();
+    final hasAcceptedAt = reader.readBool();
+    final acceptedAt = hasAcceptedAt ? reader.read() as DateTime : null;
+    final locale = reader.readString();
+    return ConsentState(
+      accepted: accepted,
+      acceptedAt: acceptedAt,
+      locale: locale,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ConsentState obj) {
+    writer
+      ..writeBool(obj.accepted)
+      ..writeBool(obj.acceptedAt != null);
+    if (obj.acceptedAt != null) {
+      writer.write(obj.acceptedAt!);
+    }
+    writer.writeString(obj.locale);
+  }
+}

--- a/lib/features/onboarding/screens/consent_screen.dart
+++ b/lib/features/onboarding/screens/consent_screen.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/features/onboarding/state/consent_notifier.dart';
+import 'package:free_base/services/app_routes.dart';
+import 'package:free_base/services/feature_flags.dart';
+import 'package:free_base/services/telemetry/telemetry_service.dart';
+import 'package:free_base/widgets/fallback_scaffold.dart';
+
+class ConsentScreen extends StatefulWidget {
+  const ConsentScreen({super.key});
+
+  @override
+  State<ConsentScreen> createState() => _ConsentScreenState();
+}
+
+class _ConsentScreenState extends State<ConsentScreen> {
+  bool _loggedShown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_loggedShown) {
+      _loggedShown = true;
+      final telemetry = context.read<TelemetryService>();
+      final locale = Localizations.maybeLocaleOf(context)?.toLanguageTag() ?? 'de';
+      telemetry.logEvent('consent_shown', properties: {
+        'locale': locale,
+      });
+    }
+  }
+
+  Future<void> _acceptConsent() async {
+    final locale = Localizations.maybeLocaleOf(context)?.toLanguageTag() ?? 'de';
+    final consentNotifier = context.read<ConsentNotifier>();
+    await consentNotifier.accept(locale: locale);
+
+    final telemetry = context.read<TelemetryService>();
+    await telemetry.logEvent('consent_accepted', properties: {
+      'locale': locale,
+    });
+
+    if (!mounted) return;
+    final featureFlags = context.read<FeatureFlags>();
+    final targetRoute = featureFlags.consentRequired
+        ? AppRouteNames.dashboard
+        : AppRouteNames.training;
+    context.goNamed(targetRoute);
+  }
+
+  void _showDeclineInfo() {
+    final messenger = ScaffoldMessenger.of(context);
+    final theme = Theme.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Du musst den Datenschutzbestimmungen zustimmen, um Corejourney zu nutzen.',
+          style: theme.textTheme.bodyMedium?.copyWith(color: Colors.white),
+        ),
+        backgroundColor: theme.colorScheme.error,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final locale = Localizations.maybeLocaleOf(context)?.languageCode.toLowerCase();
+    final isGerman = locale == 'de';
+
+    return FallbackScaffold(
+      title: isGerman ? 'Datenschutz' : 'Privacy',
+      headline: isGerman ? 'Einwilligung erforderlich' : 'Consent required',
+      message: isGerman
+          ? 'Um Corejourney zu nutzen, benötigen wir deine Zustimmung zur vorläufigen Datenschutzerklärung. Die finalen Texte folgen in einer späteren Version.'
+          : 'To continue using Corejourney you need to accept the placeholder privacy agreement. The final copy will arrive in a future update.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            isGerman ? 'Wichtige Punkte' : 'Key points',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          _ConsentBullet(
+            text: isGerman
+                ? 'Deine Trainingsfortschritte werden lokal gespeichert und bei Verbindung synchronisiert.'
+                : 'Your training progress is stored locally and synchronised once you are online.',
+          ),
+          _ConsentBullet(
+            text: isGerman
+                ? 'Telemetry-Events helfen uns, App-Start und Onboarding technisch zu überwachen.'
+                : 'Telemetry events allow us to understand app launches and onboarding completions.',
+          ),
+          _ConsentBullet(
+            text: isGerman
+                ? 'Du kannst den Fragebogen jederzeit pausieren oder neu starten.'
+                : 'You can pause or restart the questionnaire at any time.',
+          ),
+        ],
+      ),
+      primaryActionLabel:
+          isGerman ? 'Zustimmen und fortfahren' : 'Accept and continue',
+      onPrimaryAction: _acceptConsent,
+      secondaryActionLabel: isGerman ? 'Ablehnen' : 'Decline',
+      onSecondaryAction: _showDeclineInfo,
+      icon: Icons.privacy_tip_outlined,
+    );
+  }
+}
+
+class _ConsentBullet extends StatelessWidget {
+  final String text;
+
+  const _ConsentBullet({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('• ', style: TextStyle(fontSize: 18)),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/screens/login_screen.dart
+++ b/lib/features/onboarding/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:free_base/features/onboarding/services/auth_service.dart';
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/error_handler.dart';
+import 'package:free_base/widgets/connectivity_banner.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -62,43 +63,50 @@ class LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Anmelden')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            TextField(
-              controller: _emailController,
-              decoration: const InputDecoration(labelText: 'E-Mail'),
+      body: Column(
+        children: [
+          const ConnectivityBanner(),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextField(
+                    controller: _emailController,
+                    decoration: const InputDecoration(labelText: 'E-Mail'),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: _passwordController,
+                    decoration: const InputDecoration(labelText: 'Passwort'),
+                    obscureText: true,
+                  ),
+                  const SizedBox(height: 16),
+                  if (_error != null) ...[
+                    Text(_error!, style: const TextStyle(color: Colors.red)),
+                    const SizedBox(height: 8),
+                  ],
+                  ElevatedButton(
+                    onPressed: _isLoading ? null : _login,
+                    child: _isLoading
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Anmelden'),
+                  ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: () => context.pushNamed(AppRouteNames.register),
+                    child: const Text('Noch keinen Account? Registrieren'),
+                  ),
+                ],
+              ),
             ),
-            const SizedBox(height: 8),
-            TextField(
-              controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Passwort'),
-              obscureText: true,
-            ),
-            const SizedBox(height: 16),
-            if (_error != null) ...[
-              Text(_error!, style: const TextStyle(color: Colors.red)),
-              const SizedBox(height: 8),
-            ],
-            ElevatedButton(
-              onPressed: _isLoading ? null : _login,
-              child: _isLoading
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Anmelden'),
-            ),
-            const SizedBox(height: 12),
-            TextButton(
-              onPressed: () => context.pushNamed(AppRouteNames.register),
-              child: const Text('Noch keinen Account? Registrieren'),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/onboarding/state/consent_notifier.dart
+++ b/lib/features/onboarding/state/consent_notifier.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import 'package:free_base/features/onboarding/models/consent_state.dart';
+
+/// ChangeNotifier that exposes the stored consent state and updates it.
+class ConsentNotifier extends ChangeNotifier {
+  static const _consentKey = 'consent';
+
+  final Box<ConsentState> _box;
+  ConsentState _state;
+
+  ConsentNotifier(
+    this._box, {
+    String? defaultLocale,
+  }) : _state = _box.get(
+          _consentKey,
+          defaultValue: ConsentState(
+            accepted: false,
+            acceptedAt: null,
+            locale: defaultLocale ?? 'de',
+          ),
+        ) ??
+            ConsentState(
+              accepted: false,
+              acceptedAt: null,
+              locale: defaultLocale ?? 'de',
+            );
+
+  ConsentState get state => _state;
+  bool get hasAccepted => _state.accepted;
+
+  Future<void> accept({required String locale}) async {
+    final updated = _state.copyWith(
+      accepted: true,
+      acceptedAt: DateTime.now(),
+      locale: locale,
+    );
+    _state = updated;
+    await _box.put(_consentKey, updated);
+    notifyListeners();
+  }
+
+  Future<void> reset() async {
+    final resetState = ConsentState(
+      accepted: false,
+      acceptedAt: null,
+      locale: _state.locale,
+    );
+    _state = resetState;
+    await _box.put(_consentKey, resetState);
+    notifyListeners();
+  }
+}

--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -4,6 +4,10 @@ import 'package:provider/provider.dart';
 
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/error_handler.dart';
+import 'package:free_base/services/feature_flags.dart';
+import 'package:free_base/services/telemetry/telemetry_service.dart';
+
+import 'package:free_base/features/training/notifier/session_notifier.dart';
 
 import 'questionnaire_state.dart';
 
@@ -59,6 +63,17 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
       await context
           .read<QuestionnaireState>()
           .saveResult(name: trimmed, context: context);
+
+      context.read<SessionNotifier>().markOnboardingComplete();
+      final telemetry = context.read<TelemetryService>();
+      final featureFlags = context.read<FeatureFlags>();
+      final locale = Localizations.maybeLocaleOf(context)?.toLanguageTag() ?? 'de';
+      await telemetry.logEvent('onboarding_complete', properties: {
+        'locale': locale,
+        'feature_flag_snapshot': featureFlags.toMap().toString(),
+        'connectivity_status': 'unknown',
+      });
+
       if (!context.mounted) return;
       context.goNamed(AppRouteNames.profile);
     } catch (e) {

--- a/lib/features/training/models/session_state.dart
+++ b/lib/features/training/models/session_state.dart
@@ -16,6 +16,7 @@ class SessionState with _$SessionState {
     DateTime? endAt,
     DateTime? plannedFor,
     @Default(SessionStatus.planned) SessionStatus status,
+    @Default(false) bool onboardingComplete,
   }) = _SessionState;
 
   factory SessionState.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/training/models/session_state.freezed.dart
+++ b/lib/features/training/models/session_state.freezed.dart
@@ -29,6 +29,7 @@ mixin _$SessionState {
   DateTime? get endAt => throw _privateConstructorUsedError;
   DateTime? get plannedFor => throw _privateConstructorUsedError;
   SessionStatus get status => throw _privateConstructorUsedError;
+  bool get onboardingComplete => throw _privateConstructorUsedError;
 
   /// Serializes this SessionState to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -55,7 +56,8 @@ abstract class $SessionStateCopyWith<$Res> {
       DateTime startedAt,
       DateTime? endAt,
       DateTime? plannedFor,
-      SessionStatus status});
+      SessionStatus status,
+      bool onboardingComplete});
 }
 
 /// @nodoc
@@ -82,6 +84,7 @@ class _$SessionStateCopyWithImpl<$Res, $Val extends SessionState>
     Object? endAt = freezed,
     Object? plannedFor = freezed,
     Object? status = null,
+    Object? onboardingComplete = null,
   }) {
     return _then(_value.copyWith(
       phaseId: null == phaseId
@@ -120,6 +123,10 @@ class _$SessionStateCopyWithImpl<$Res, $Val extends SessionState>
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
               as SessionStatus,
+      onboardingComplete: null == onboardingComplete
+          ? _value.onboardingComplete
+          : onboardingComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -141,7 +148,8 @@ abstract class _$$SessionStateImplCopyWith<$Res>
       DateTime startedAt,
       DateTime? endAt,
       DateTime? plannedFor,
-      SessionStatus status});
+      SessionStatus status,
+      bool onboardingComplete});
 }
 
 /// @nodoc
@@ -166,6 +174,7 @@ class __$$SessionStateImplCopyWithImpl<$Res>
     Object? endAt = freezed,
     Object? plannedFor = freezed,
     Object? status = null,
+    Object? onboardingComplete = null,
   }) {
     return _then(_$SessionStateImpl(
       phaseId: null == phaseId
@@ -204,6 +213,10 @@ class __$$SessionStateImplCopyWithImpl<$Res>
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
               as SessionStatus,
+      onboardingComplete: null == onboardingComplete
+          ? _value.onboardingComplete
+          : onboardingComplete // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -220,7 +233,8 @@ class _$SessionStateImpl implements _SessionState {
       required this.startedAt,
       this.endAt,
       this.plannedFor,
-      this.status = SessionStatus.planned});
+      this.status = SessionStatus.planned,
+      this.onboardingComplete = false});
 
   factory _$SessionStateImpl.fromJson(Map<String, dynamic> json) =>
       _$$SessionStateImplFromJson(json);
@@ -245,10 +259,13 @@ class _$SessionStateImpl implements _SessionState {
   @override
   @JsonKey()
   final SessionStatus status;
+  @override
+  @JsonKey()
+  final bool onboardingComplete;
 
   @override
   String toString() {
-    return 'SessionState(phaseId: $phaseId, exerciseIndex: $exerciseIndex, completedReps: $completedReps, remainingSeconds: $remainingSeconds, isPaused: $isPaused, startedAt: $startedAt, endAt: $endAt, plannedFor: $plannedFor, status: $status)';
+    return 'SessionState(phaseId: $phaseId, exerciseIndex: $exerciseIndex, completedReps: $completedReps, remainingSeconds: $remainingSeconds, isPaused: $isPaused, startedAt: $startedAt, endAt: $endAt, plannedFor: $plannedFor, status: $status, onboardingComplete: $onboardingComplete)';
   }
 
   @override
@@ -270,14 +287,16 @@ class _$SessionStateImpl implements _SessionState {
             (identical(other.endAt, endAt) || other.endAt == endAt) &&
             (identical(other.plannedFor, plannedFor) ||
                 other.plannedFor == plannedFor) &&
-            (identical(other.status, status) || other.status == status));
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.onboardingComplete, onboardingComplete) ||
+                other.onboardingComplete == onboardingComplete));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, phaseId, exerciseIndex,
       completedReps, remainingSeconds, isPaused, startedAt, endAt, plannedFor,
-      status);
+      status, onboardingComplete);
 
   /// Create a copy of SessionState
   /// with the given fields replaced by the non-null parameter values.
@@ -305,7 +324,8 @@ abstract class _SessionState implements SessionState {
       required final DateTime startedAt,
       final DateTime? endAt,
       final DateTime? plannedFor,
-      final SessionStatus status}) = _$SessionStateImpl;
+      final SessionStatus status,
+      final bool onboardingComplete}) = _$SessionStateImpl;
 
   factory _SessionState.fromJson(Map<String, dynamic> json) =
       _$SessionStateImpl.fromJson;
@@ -328,6 +348,8 @@ abstract class _SessionState implements SessionState {
   DateTime? get plannedFor;
   @override
   SessionStatus get status;
+  @override
+  bool get onboardingComplete;
 
   /// Create a copy of SessionState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/features/training/models/session_state.g.dart
+++ b/lib/features/training/models/session_state.g.dart
@@ -22,6 +22,7 @@ _$SessionStateImpl _$$SessionStateImplFromJson(Map<String, dynamic> json) =>
           : DateTime.parse(json['plannedFor'] as String),
       status: $enumDecodeNullable(_$SessionStatusEnumMap, json['status']) ??
           SessionStatus.planned,
+      onboardingComplete: json['onboardingComplete'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$$SessionStateImplToJson(_$SessionStateImpl instance) =>
@@ -35,6 +36,7 @@ Map<String, dynamic> _$$SessionStateImplToJson(_$SessionStateImpl instance) =>
       'endAt': instance.endAt?.toIso8601String(),
       'plannedFor': instance.plannedFor?.toIso8601String(),
       'status': _$SessionStatusEnumMap[instance.status]!,
+      'onboardingComplete': instance.onboardingComplete,
     };
 
 const _$SessionStatusEnumMap = {

--- a/lib/features/training/models/session_state_adapter.dart
+++ b/lib/features/training/models/session_state_adapter.dart
@@ -36,9 +36,14 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
     final status = reader.read() as SessionStatus;
 
     DateTime? plannedFor;
+    bool onboardingComplete = false;
     if (reader.availableBytes > 0) {
       final hasPlannedFor = reader.readBool();
       plannedFor = hasPlannedFor ? reader.read() as DateTime : null;
+    }
+
+    if (reader.availableBytes > 0) {
+      onboardingComplete = reader.readBool();
     }
 
     return SessionState(
@@ -51,6 +56,7 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
       endAt: endAt,
       status: status,
       plannedFor: plannedFor,
+      onboardingComplete: onboardingComplete,
     );
   }
 
@@ -78,5 +84,7 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
     } else {
       writer.writeBool(false);
     }
+
+    writer.writeBool(obj.onboardingComplete);
   }
 }

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -111,8 +111,15 @@ class SessionNotifier extends ChangeNotifier {
       startedAt: plannedFor,
       plannedFor: plannedFor,
       status: SessionStatus.planned,
+      onboardingComplete: state.onboardingComplete,
     );
     _phaseStart = DateTime.now();
+  }
+
+  void markOnboardingComplete() {
+    if (!state.onboardingComplete) {
+      state = state.copyWith(onboardingComplete: true);
+    }
   }
 
   void _tick(Timer timer) {
@@ -226,8 +233,10 @@ class SessionNotifier extends ChangeNotifier {
   void _markFirstSessionCompleted() {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
+      markOnboardingComplete();
       return;
     }
+    markOnboardingComplete();
     // Fire-and-forget: der Guard liest das Flag beim nächsten Start.
     unawaited(
       FirebaseFirestore.instance

--- a/lib/features/training/widgets/session_sync_listener.dart
+++ b/lib/features/training/widgets/session_sync_listener.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:free_base/features/training/services/sync_service.dart';
+import 'package:free_base/services/telemetry/telemetry_service.dart';
 
 class SessionSyncListener extends StatefulWidget {
   final Widget child;
@@ -67,6 +68,16 @@ class _SessionSyncListenerState extends State<SessionSyncListener> {
             ),
           ],
         ),
+      ),
+    );
+
+    final telemetry = context.read<TelemetryService>();
+    unawaited(
+      telemetry.logEvent(
+        'session_sync',
+        properties: {
+          'status': isSuccess ? 'success' : 'failure',
+        },
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
@@ -12,6 +14,7 @@ import 'package:free_base/firebase_options.dart';
 import 'package:free_base/features/onboarding/services/auth_service.dart';
 import 'package:free_base/features/onboarding/services/secure_storage_service.dart';
 import 'package:free_base/features/onboarding/state/auth_provider.dart';
+import 'package:free_base/features/onboarding/state/consent_notifier.dart';
 import 'package:free_base/features/common/error_screen.dart';
 
 import 'package:free_base/features/training/models/session_state.dart';
@@ -31,12 +34,17 @@ import 'package:free_base/services/app_intent_handler.dart';
 import 'package:free_base/services/app_route_guard.dart';
 import 'package:free_base/services/app_router.dart';
 import 'package:free_base/services/feature_flags.dart';
+import 'package:free_base/services/telemetry/telemetry_service.dart';
+
+import 'package:free_base/features/onboarding/models/consent_state.dart';
 
 const FeatureFlags _localFeatureFlags = FeatureFlags(
   parentsTrackEnabled: true,
   trainerTrackEnabled: true,
   forumEnabled: false,
   achievementsEnabled: false,
+  consentRequired: true,
+  remindersEnabled: false,
 );
 
 Future<void> main() async {
@@ -76,7 +84,11 @@ Future<void> main() async {
 
   Hive.registerAdapter(SessionStatusAdapter());
   Hive.registerAdapter(SessionStateAdapter());
+  Hive.registerAdapter(ConsentStateAdapter());
   await Hive.openBox<SessionState>('session_state',
+      encryptionCipher: HiveAesCipher(encryptionKey));
+
+  final consentBox = await Hive.openBox<ConsentState>('user_settings',
       encryptionCipher: HiveAesCipher(encryptionKey));
 
   await Hive.openBox('questionnaire_progress',
@@ -105,6 +117,7 @@ Future<void> main() async {
     MyApp(
       sessionRepository: sessionRepository,
       initialSessionState: initialSessionState,
+      consentBox: consentBox,
     ),
   );
 }
@@ -112,6 +125,7 @@ Future<void> main() async {
 class MyApp extends StatefulWidget {
   final SessionRepository sessionRepository;
   final SessionState initialSessionState;
+  final Box<ConsentState> consentBox;
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
       GlobalKey<ScaffoldMessengerState>();
 
@@ -119,6 +133,7 @@ class MyApp extends StatefulWidget {
     super.key,
     required this.sessionRepository,
     required this.initialSessionState,
+    required this.consentBox,
   });
 
   @override
@@ -126,14 +141,43 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  late final AppRouteGuard _routeGuard = AppRouteGuard();
+  final TelemetryService _telemetry = DebugTelemetryService();
+  late final ConsentNotifier _consentNotifier;
+  late final AppRouteGuard _routeGuard;
   GoRouter? _router;
   AppIntentHandler? _intentHandler;
   bool _intentInitialized = false;
 
   @override
+  void initState() {
+    super.initState();
+    final localeTag =
+        WidgetsBinding.instance.platformDispatcher.locale.toLanguageTag();
+    _consentNotifier = ConsentNotifier(
+      widget.consentBox,
+      defaultLocale: localeTag,
+    );
+    _routeGuard = AppRouteGuard(
+      consentNotifier: _consentNotifier,
+      loadSessionState: widget.sessionRepository.load,
+      consentRequired: _localFeatureFlags.consentRequired,
+    );
+    unawaited(
+      _telemetry.logEvent(
+        'app_open',
+        properties: {
+          'locale': localeTag,
+          'feature_flag_snapshot': _localFeatureFlags.toMap().toString(),
+          'connectivity_status': 'unknown',
+        },
+      ),
+    );
+  }
+
+  @override
   void dispose() {
     _intentHandler?.dispose();
+    _consentNotifier.dispose();
     super.dispose();
   }
 
@@ -144,8 +188,14 @@ class _MyAppState extends State<MyApp> {
         Provider<FeatureFlags>.value(
           value: _localFeatureFlags,
         ),
+        Provider<TelemetryService>.value(
+          value: _telemetry,
+        ),
         ChangeNotifierProvider<AppAuthProvider>(
           create: (_) => AppAuthProvider(),
+        ),
+        ChangeNotifierProvider<ConsentNotifier>.value(
+          value: _consentNotifier,
         ),
         Provider<AuthService>(
           create: (_) => AuthService(),
@@ -191,8 +241,12 @@ class _MyAppState extends State<MyApp> {
       child: Builder(
         builder: (context) {
           final authProvider = context.watch<AppAuthProvider>();
+          final consentNotifier = context.watch<ConsentNotifier>();
+          final sessionNotifier = context.watch<SessionNotifier>();
+          final refreshListenable =
+              Listenable.merge([authProvider, consentNotifier, sessionNotifier]);
           _router ??= AppRouter(
-            refreshListenable: authProvider,
+            refreshListenable: refreshListenable,
             guard: _routeGuard,
           ).router;
 

--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -2,20 +2,40 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:free_base/features/onboarding/state/consent_notifier.dart';
+import 'package:free_base/features/training/models/session_state.dart';
 import 'package:free_base/services/app_routes.dart';
 
 class AppRouteGuard {
   AppRouteGuard({
     FirebaseAuth? auth,
     FirebaseFirestore? firestore,
+    required ConsentNotifier consentNotifier,
+    required Future<SessionState?> Function() loadSessionState,
+    bool consentRequired = true,
+    Future<Map<String, dynamic>> Function(String uid)? userDataLoader,
   })  : _auth = auth ?? FirebaseAuth.instance,
-        _firestore = firestore ?? FirebaseFirestore.instance;
+        _consentNotifier = consentNotifier,
+        _loadSessionState = loadSessionState,
+        _consentRequired = consentRequired,
+        _userDataLoader = userDataLoader ??
+            ((uid) async {
+              final doc = (firestore ?? FirebaseFirestore.instance)
+                  .collection('users')
+                  .doc(uid);
+              final snapshot = await doc.get();
+              return snapshot.data() ?? const <String, dynamic>{};
+            });
 
   final FirebaseAuth _auth;
-  final FirebaseFirestore _firestore;
+  final ConsentNotifier _consentNotifier;
+  final Future<SessionState?> Function() _loadSessionState;
+  final bool _consentRequired;
+  final Future<Map<String, dynamic>> Function(String uid) _userDataLoader;
   Map<String, dynamic>? _cachedUserData;
   bool _isFetching = false;
 
@@ -23,10 +43,19 @@ class AppRouteGuard {
     AppRoutePaths.splash,
     AppRoutePaths.login,
     AppRoutePaths.register,
+    AppRoutePaths.consent,
   };
 
   FutureOr<String?> redirect(BuildContext context, GoRouterState state) async {
-    final location = state.matchedLocation;
+    return _resolveRedirect(state.matchedLocation);
+  }
+
+  @visibleForTesting
+  Future<String?> evaluateLocation(String location) {
+    return _resolveRedirect(location);
+  }
+
+  Future<String?> _resolveRedirect(String location) async {
     final user = _auth.currentUser;
 
     if (user == null) {
@@ -36,15 +65,28 @@ class AppRouteGuard {
       return AppRoutePaths.login;
     }
 
+    if (_consentRequired) {
+      final hasConsent = _consentNotifier.hasAccepted;
+      if (!hasConsent && location != AppRoutePaths.consent) {
+        return AppRoutePaths.consent;
+      }
+      if (hasConsent && location == AppRoutePaths.consent) {
+        return AppRoutePaths.dashboard;
+      }
+    }
+
     final data = await _loadUserData(user.uid);
     final role = (data['role'] as String?)?.trim();
     final firstSessionCompleted = (data['firstSessionCompleted'] as bool?) ?? false;
+    final localSession = await _loadSessionState();
+    final onboardingComplete =
+        (localSession?.onboardingComplete ?? false) || firstSessionCompleted;
 
     if ((role == null || role.isEmpty) && location != AppRoutePaths.roleSelection) {
       return AppRoutePaths.roleSelection;
     }
 
-    if (_requiresFirstSession(location) && !firstSessionCompleted) {
+    if (_requiresOnboardingComplete(location) && !onboardingComplete) {
       if (location != AppRoutePaths.training) {
         return AppRoutePaths.training;
       }
@@ -61,13 +103,14 @@ class AppRouteGuard {
     return _publicRoutes.contains(location);
   }
 
-  bool _requiresFirstSession(String location) {
+  bool _requiresOnboardingComplete(String location) {
     if (location == AppRoutePaths.training ||
         location == AppRoutePaths.trainingCompleted ||
         location == AppRoutePaths.dashboard ||
-        // Calendar should remain reachable from the bottom navigation
-        // even before completing the onboarding session.
-        location.startsWith(AppRoutePaths.calendar)) {
+        location == AppRoutePaths.consent ||
+        location.startsWith(AppRoutePaths.calendar) ||
+        location.startsWith(AppRoutePaths.questionnaireIntro) ||
+        location.startsWith(AppRoutePaths.questionnaire)) {
       return false;
     }
     if (location.startsWith(AppRoutePaths.training)) {
@@ -89,8 +132,7 @@ class AppRouteGuard {
 
     try {
       _isFetching = true;
-      final doc = await _firestore.collection('users').doc(uid).get();
-      _cachedUserData = doc.data() ?? const <String, dynamic>{};
+      _cachedUserData = await _userDataLoader(uid);
     } finally {
       _isFetching = false;
     }

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -9,6 +9,7 @@ import 'package:free_base/features/common/error_screen.dart';
 import 'package:free_base/features/common/feature_placeholder_screen.dart';
 import 'package:free_base/features/common/splash_screen.dart';
 import 'package:free_base/features/onboarding/profile/settings_screen.dart';
+import 'package:free_base/features/onboarding/screens/consent_screen.dart';
 import 'package:free_base/features/onboarding/screens/login_screen.dart';
 import 'package:free_base/features/onboarding/screens/register_screen.dart';
 import 'package:free_base/features/onboarding/screens/role_selection_screen.dart';
@@ -64,6 +65,11 @@ class AppRouter {
         path: AppRoutePaths.register,
         name: AppRouteNames.register,
         builder: (context, state) => const RegisterScreen(),
+      ),
+      GoRoute(
+        path: AppRoutePaths.consent,
+        name: AppRouteNames.consent,
+        builder: (context, state) => const ConsentScreen(),
       ),
       GoRoute(
         path: AppRoutePaths.roleSelection,

--- a/lib/services/app_routes.dart
+++ b/lib/services/app_routes.dart
@@ -2,6 +2,7 @@ class AppRoutePaths {
   static const splash = '/';
   static const login = '/login';
   static const register = '/register';
+  static const consent = '/consent';
   static const roleSelection = '/select-role';
   static const dashboard = '/dashboard';
   static const training = '/training';
@@ -21,6 +22,7 @@ class AppRouteNames {
   static const splash = 'splash';
   static const login = 'login';
   static const register = 'register';
+  static const consent = 'consent';
   static const roleSelection = 'roleSelection';
   static const dashboard = 'dashboard';
   static const training = 'training';

--- a/lib/services/feature_flags.dart
+++ b/lib/services/feature_flags.dart
@@ -8,12 +8,16 @@ class FeatureFlags {
   final bool trainerTrackEnabled;
   final bool forumEnabled;
   final bool achievementsEnabled;
+  final bool consentRequired;
+  final bool remindersEnabled;
 
   const FeatureFlags({
     this.parentsTrackEnabled = false,
     this.trainerTrackEnabled = false,
     this.forumEnabled = false,
     this.achievementsEnabled = false,
+    this.consentRequired = true,
+    this.remindersEnabled = false,
   });
 
   FeatureFlags copyWith({
@@ -21,6 +25,8 @@ class FeatureFlags {
     bool? trainerTrackEnabled,
     bool? forumEnabled,
     bool? achievementsEnabled,
+    bool? consentRequired,
+    bool? remindersEnabled,
   }) {
     return FeatureFlags(
       parentsTrackEnabled:
@@ -30,6 +36,19 @@ class FeatureFlags {
       forumEnabled: forumEnabled ?? this.forumEnabled,
       achievementsEnabled:
           achievementsEnabled ?? this.achievementsEnabled,
+      consentRequired: consentRequired ?? this.consentRequired,
+      remindersEnabled: remindersEnabled ?? this.remindersEnabled,
     );
+  }
+
+  Map<String, bool> toMap() {
+    return {
+      'parentsTrackEnabled': parentsTrackEnabled,
+      'trainerTrackEnabled': trainerTrackEnabled,
+      'forumEnabled': forumEnabled,
+      'achievementsEnabled': achievementsEnabled,
+      'consentRequired': consentRequired,
+      'remindersEnabled': remindersEnabled,
+    };
   }
 }

--- a/lib/services/telemetry/telemetry_service.dart
+++ b/lib/services/telemetry/telemetry_service.dart
@@ -1,0 +1,31 @@
+import 'dart:developer' as developer;
+
+/// Lightweight abstraction for emitting analytics/telemetry events.
+abstract class TelemetryService {
+  Future<void> logEvent(
+    String name, {
+    Map<String, Object?>? properties,
+  });
+
+  Future<void> setUserId(String? userId) async {}
+  Future<void> setUserProperties(Map<String, Object?> properties) async {}
+}
+
+/// Default debug implementation writing events to the developer log.
+class DebugTelemetryService implements TelemetryService {
+  @override
+  Future<void> logEvent(
+    String name, {
+    Map<String, Object?>? properties,
+  }) async {
+    final payload = properties == null || properties.isEmpty
+        ? ''
+        : properties.entries
+            .map((entry) => '${entry.key}=${entry.value}')
+            .join(', ');
+    developer.log(
+      'event:$name${payload.isEmpty ? '' : ' {$payload}'}',
+      name: 'telemetry',
+    );
+  }
+}

--- a/lib/widgets/fallback_scaffold.dart
+++ b/lib/widgets/fallback_scaffold.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+import 'package:free_base/widgets/connectivity_banner.dart';
+
+/// Reusable scaffold that combines a connectivity banner and a fallback
+/// message area with optional retry/action buttons.
+class FallbackScaffold extends StatelessWidget {
+  final String title;
+  final String headline;
+  final String message;
+  final Widget? child;
+  final String? primaryActionLabel;
+  final VoidCallback? onPrimaryAction;
+  final String? secondaryActionLabel;
+  final VoidCallback? onSecondaryAction;
+  final IconData icon;
+
+  const FallbackScaffold({
+    super.key,
+    required this.title,
+    required this.headline,
+    required this.message,
+    this.child,
+    this.primaryActionLabel,
+    this.onPrimaryAction,
+    this.secondaryActionLabel,
+    this.onSecondaryAction,
+    this.icon = Icons.info_outline,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final content = <Widget>[
+      Icon(icon, size: 48, color: theme.colorScheme.primary),
+      const SizedBox(height: 16),
+      Text(
+        headline,
+        style: theme.textTheme.headlineSmall?.copyWith(
+          color: theme.colorScheme.onSurface,
+        ),
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: 12),
+      Text(
+        message,
+        style: theme.textTheme.bodyMedium,
+        textAlign: TextAlign.center,
+      ),
+    ];
+
+    if (child != null) {
+      content
+        ..add(const SizedBox(height: 16))
+        ..add(child!);
+    }
+
+    final actions = <Widget>[];
+    if (primaryActionLabel != null && onPrimaryAction != null) {
+      actions.add(
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: onPrimaryAction,
+            child: Text(primaryActionLabel!),
+          ),
+        ),
+      );
+    }
+    if (secondaryActionLabel != null && onSecondaryAction != null) {
+      actions
+        ..add(const SizedBox(height: 8))
+        ..add(
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: onSecondaryAction,
+              child: Text(secondaryActionLabel!),
+            ),
+          ),
+        );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Column(
+        children: [
+          const ConnectivityBanner(),
+          Expanded(
+            child: Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    ...content,
+                    if (actions.isNotEmpty) ...[
+                      const SizedBox(height: 24),
+                      ...actions,
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/services/app_route_guard_test.dart
+++ b/test/services/app_route_guard_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:free_base/features/onboarding/models/consent_state.dart';
+import 'package:free_base/features/onboarding/state/consent_notifier.dart';
+import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/services/app_route_guard.dart';
+import 'package:free_base/services/app_routes.dart';
+
+void main() {
+  late Directory tempDir;
+  late Box<ConsentState> consentBox;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('guard_test');
+    Hive.init(tempDir.path);
+    if (!Hive.isAdapterRegistered(ConsentState.hiveTypeId)) {
+      Hive.registerAdapter(ConsentStateAdapter());
+    }
+    consentBox = await Hive.openBox<ConsentState>('consent_box');
+  });
+
+  tearDown(() async {
+    await consentBox.clear();
+  });
+
+  tearDownAll(() async {
+    await consentBox.close();
+    await Hive.deleteFromDisk();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<ConsentNotifier> createNotifier({bool accepted = false}) async {
+    final notifier = ConsentNotifier(consentBox, defaultLocale: 'de');
+    if (accepted) {
+      await notifier.accept(locale: 'de');
+    }
+    return notifier;
+  }
+
+  SessionState buildSessionState({bool onboardingComplete = false}) {
+    final plannedFor = DateTime.now().add(const Duration(days: 1));
+    return SessionState(
+      phaseId: 'phase',
+      exerciseIndex: 0,
+      completedReps: 0,
+      remainingSeconds: 8,
+      startedAt: plannedFor,
+      plannedFor: plannedFor,
+      status: SessionStatus.planned,
+      onboardingComplete: onboardingComplete,
+    );
+  }
+
+  group('AppRouteGuard', () {
+    test('redirects anonymous users to login for protected routes', () async {
+      final consentNotifier = await createNotifier();
+      final auth = MockFirebaseAuth();
+      final guard = AppRouteGuard(
+        auth: auth,
+        consentNotifier: consentNotifier,
+        loadSessionState: () async => null,
+        consentRequired: true,
+        userDataLoader: (_) async => const <String, dynamic>{},
+      );
+
+      final redirect = await guard.evaluateLocation(AppRoutePaths.dashboard);
+      expect(redirect, AppRoutePaths.login);
+
+      consentNotifier.dispose();
+    });
+
+    test('redirects to consent screen when consent is missing', () async {
+      final consentNotifier = await createNotifier();
+      final auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u1'), signedIn: true);
+      final guard = AppRouteGuard(
+        auth: auth,
+        consentNotifier: consentNotifier,
+        loadSessionState: () async => buildSessionState(onboardingComplete: false),
+        consentRequired: true,
+        userDataLoader: (_) async => const <String, dynamic>{'role': 'member'},
+      );
+
+      final redirect = await guard.evaluateLocation(AppRoutePaths.dashboard);
+      expect(redirect, AppRoutePaths.consent);
+
+      consentNotifier.dispose();
+    });
+
+    test('redirects to training when onboarding is not complete', () async {
+      final consentNotifier = await createNotifier(accepted: true);
+      final auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u2'), signedIn: true);
+      final guard = AppRouteGuard(
+        auth: auth,
+        consentNotifier: consentNotifier,
+        loadSessionState: () async => buildSessionState(onboardingComplete: false),
+        consentRequired: true,
+        userDataLoader: (_) async => const <String, dynamic>{
+          'role': 'member',
+          'firstSessionCompleted': false,
+        },
+      );
+
+      final redirect = await guard.evaluateLocation(AppRoutePaths.dashboard);
+      expect(redirect, AppRoutePaths.training);
+
+      consentNotifier.dispose();
+    });
+
+    test('allows dashboard when consent and onboarding are complete', () async {
+      final consentNotifier = await createNotifier(accepted: true);
+      final auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u3'), signedIn: true);
+      final guard = AppRouteGuard(
+        auth: auth,
+        consentNotifier: consentNotifier,
+        loadSessionState: () async => buildSessionState(onboardingComplete: true),
+        consentRequired: true,
+        userDataLoader: (_) async => const <String, dynamic>{
+          'role': 'member',
+          'firstSessionCompleted': true,
+        },
+      );
+
+      final redirect = await guard.evaluateLocation(AppRoutePaths.dashboard);
+      expect(redirect, isNull);
+
+      final consentRedirect = await guard.evaluateLocation(AppRoutePaths.consent);
+      expect(consentRedirect, AppRoutePaths.dashboard);
+
+      consentNotifier.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- persist consent status in Hive with a notifier, placeholder screen, and splash/route guard redirects
- wire telemetry service into app startup, consent, sync notifications, and questionnaire completion events
- extend session state with onboarding awareness, add reusable fallback scaffold, and cover guard logic with tests

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69048c771b50832d9be3f1f9d197f684