### PR TITLE
Fix telemetry contract and stabilize login test

### DIFF
--- a/lib/features/onboarding/screens/login_screen.dart
+++ b/lib/features/onboarding/screens/login_screen.dart
@@ -14,7 +14,11 @@ class LoginScreen extends StatefulWidget {
 }
 
 class LoginScreenState extends State<LoginScreen> {
-  final _emailController    = TextEditingController();
+  static const emailFieldKey = ValueKey('login_email_field');
+  static const passwordFieldKey = ValueKey('login_password_field');
+  static const submitButtonKey = ValueKey('login_submit_button');
+
+  final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _isLoading = false;
   String? _error;
@@ -73,11 +77,13 @@ class LoginScreenState extends State<LoginScreen> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   TextField(
+                    key: emailFieldKey,
                     controller: _emailController,
                     decoration: const InputDecoration(labelText: 'E-Mail'),
                   ),
                   const SizedBox(height: 8),
                   TextField(
+                    key: passwordFieldKey,
                     controller: _passwordController,
                     decoration: const InputDecoration(labelText: 'Passwort'),
                     obscureText: true,
@@ -88,6 +94,7 @@ class LoginScreenState extends State<LoginScreen> {
                     const SizedBox(height: 8),
                   ],
                   ElevatedButton(
+                    key: submitButtonKey,
                     onPressed: _isLoading ? null : _login,
                     child: _isLoading
                         ? const SizedBox(

--- a/lib/services/telemetry/telemetry_service.dart
+++ b/lib/services/telemetry/telemetry_service.dart
@@ -7,12 +7,16 @@ abstract class TelemetryService {
     Map<String, Object?>? properties,
   });
 
-  Future<void> setUserId(String? userId) async {}
-  Future<void> setUserProperties(Map<String, Object?> properties) async {}
+  Future<void> setUserId(String? userId);
+
+  Future<void> setUserProperties(Map<String, Object?> properties);
 }
 
 /// Default debug implementation writing events to the developer log.
 class DebugTelemetryService implements TelemetryService {
+  String? _userId;
+  Map<String, Object?> _userProperties = const {};
+
   @override
   Future<void> logEvent(
     String name, {
@@ -28,4 +32,31 @@ class DebugTelemetryService implements TelemetryService {
       name: 'telemetry',
     );
   }
+
+  @override
+  Future<void> setUserId(String? userId) async {
+    _userId = userId;
+    developer.log(
+      'userId:${userId ?? 'anonymous'}',
+      name: 'telemetry',
+    );
+  }
+
+  @override
+  Future<void> setUserProperties(Map<String, Object?> properties) async {
+    _userProperties = Map.unmodifiable(properties);
+    final payload = _userProperties.entries
+        .map((entry) => '${entry.key}=${entry.value}')
+        .join(', ');
+    developer.log(
+      'userProperties{${payload.isEmpty ? 'empty' : payload}}',
+      name: 'telemetry',
+    );
+  }
+
+  /// Exposes the last user id recorded during debugging or tests.
+  String? get debugUserId => _userId;
+
+  /// Exposes the last set of user properties recorded during debugging or tests.
+  Map<String, Object?> get debugUserProperties => _userProperties;
 }

--- a/test/login_dashboard_flow_test.dart
+++ b/test/login_dashboard_flow_test.dart
@@ -71,9 +71,14 @@ void main() {
     );
 
     await tester.enterText(
-        find.byType(TextField).at(0), 'test@example.com');
-    await tester.enterText(find.byType(TextField).at(1), 'password123');
-    await tester.tap(find.text('Anmelden'));
+      find.byKey(LoginScreenState.emailFieldKey),
+      'test@example.com',
+    );
+    await tester.enterText(
+      find.byKey(LoginScreenState.passwordFieldKey),
+      'password123',
+    );
+    await tester.tap(find.byKey(LoginScreenState.submitButtonKey));
 
     await tester.pump();
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- implement the missing TelemetryService user identity methods with logging in the debug implementation
- add deterministic keys to the login screen fields/button for widget interaction
- update the login dashboard flow test to reference the new keys

## Testing
- Not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690497b75014832db6903fdfe5da336a