### PR TITLE
Fix login dashboard flow test stubbing

### DIFF
--- a/test/login_dashboard_flow_test.dart
+++ b/test/login_dashboard_flow_test.dart
@@ -53,7 +53,7 @@ void main() {
   testWidgets('login success navigates through role selection to dashboard',
       (tester) async {
     final mockAuth = MockAuthService();
-    when(mockAuth.signInWithEmail(any<String>(), any<String>()))
+    when(mockAuth.signInWithEmail('test@example.com', 'password123'))
         .thenAnswer((_) async => FakeUserCredential());
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- stub the mocked AuthService with the expected credentials instead of using any<T>() so the analyzer no longer flags null usage

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904996a2e18832d9413dd1d8e32021b