### PR TITLE
Implement dashboard gamification summary and reminder skeleton

### DIFF
--- a/assets/images/badges/.gitkeep
+++ b/assets/images/badges/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for future badge assets

--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/training_intent.dart';
+import 'package:free_base/services/reminder/reminder_service.dart';
 
 import '../dialogs/edit_training_day_dialog.dart';
 import '../models/calendar_event.dart';
@@ -27,24 +28,21 @@ import '../widgets/month_bracket.dart';
 /// - Einträgen über BottomSheet
 /// - Edit-Dialog beim Tap auf einen Event
 class CalendarScreen extends StatelessWidget {
-  const CalendarScreen({Key? key}) : super(key: key);
+  final bool openReminder;
+
+  const CalendarScreen({Key? key, this.openReminder = false}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<CalendarNotifier>(
-      create: (ctx) {
-        final service = ctx.read<CalendarService>();
-        final notifier = CalendarNotifier(service);
-        notifier.loadMonth(DateTime.now());
-        return notifier;
-      },
-      child: const _CalendarScreenContent(),
-    );
+    return _CalendarScreenContent(openReminder: openReminder);
   }
 }
 
 class _CalendarScreenContent extends StatefulWidget {
-  const _CalendarScreenContent({Key? key}) : super(key: key);
+  final bool openReminder;
+
+  const _CalendarScreenContent({Key? key, required this.openReminder})
+      : super(key: key);
 
   @override
   State<_CalendarScreenContent> createState() =>
@@ -65,6 +63,12 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
     super.initState();
     _pageController = PageController(initialPage: _initialPage);
     _baseMonth = DateTime(DateTime.now().year, DateTime.now().month);
+    if (widget.openReminder) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _openReminderSheet();
+      });
+    }
   }
 
   int _monthDiff(DateTime a, DateTime b) =>
@@ -80,6 +84,66 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
 
   void _onPageChanged(int page) {
     context.read<CalendarNotifier>().loadMonth(_monthForIndex(page));
+  }
+
+  Future<void> _openReminderSheet() async {
+    final reminderService = context.read<ReminderService>();
+    if (!reminderService.hasScheduledReminder) {
+      await _pickReminderTime(reminderService);
+      return;
+    }
+
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.schedule),
+                title: const Text('Uhrzeit ändern'),
+                onTap: () => Navigator.of(sheetContext).pop('change'),
+              ),
+              ListTile(
+                leading: const Icon(Icons.delete_outline),
+                title: const Text('Reminder entfernen'),
+                onTap: () => Navigator.of(sheetContext).pop('cancel'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (!mounted) return;
+
+    if (action == 'change') {
+      await _pickReminderTime(reminderService);
+    } else if (action == 'cancel') {
+      await reminderService.cancelDailyReminder();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Reminder deaktiviert.')),
+      );
+    }
+  }
+
+  Future<void> _pickReminderTime(ReminderService service) async {
+    final initial = service.scheduledTime ?? const TimeOfDay(hour: 18, minute: 0);
+    final result = await showTimePicker(
+      context: context,
+      initialTime: initial,
+      helpText: 'Erinnerung auswählen',
+    );
+    if (result != null) {
+      await service.scheduleDailyReminder(result);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Reminder gesetzt für ${result.format(context)}.'),
+        ),
+      );
+    }
   }
 
 
@@ -98,7 +162,16 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
     });
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Dein Trainingskalender')),
+      appBar: AppBar(
+        title: const Text('Dein Trainingskalender'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.alarm),
+            tooltip: 'Reminder setzen',
+            onPressed: _openReminderSheet,
+          ),
+        ],
+      ),
       body: Column(
         children: [
           Container(

--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -5,6 +5,9 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 import 'package:free_base/features/common/dashboard_route_args.dart';
+import 'package:free_base/features/common/state/dashboard_view_model.dart';
+import 'package:free_base/features/common/widgets/dashboard_calendar_card.dart';
+import 'package:free_base/features/common/widgets/dashboard_header.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/features/training/widgets/session_status_banner.dart';
 import 'package:free_base/services/app_routes.dart';
@@ -47,45 +50,136 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Widget build(BuildContext context) {
     final sessionNotifier = context.watch<SessionNotifier>();
     final state = sessionNotifier.state;
+    final dashboard = context.watch<DashboardViewModel>();
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
-      body: Padding(
+      body: ListView(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SessionStatusBanner.fromSession(state),
-            const SizedBox(height: 24),
-            Text(
-              'Willkommen im Dashboard!',
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 12),
-            Text(
-              'Behalte deinen Trainingsfortschritt im Blick und starte deine nächste Einheit, wenn du bereit bist.',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const Spacer(),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () => context.goNamed(
-                  AppRouteNames.training,
+        children: [
+          DashboardHeader(
+            level: dashboard.currentLevel,
+            levelProgress: dashboard.levelProgress,
+            xpTotal: dashboard.xpTotal,
+            xpToNextLevel: dashboard.xpToNextLevel,
+            streakCount: dashboard.streakCount,
+            freezeAvailable: dashboard.freezeAvailable,
+            dailyXp: dashboard.dailyXp,
+            freezeUntil: dashboard.streakFrozenUntil,
+          ),
+          const SizedBox(height: 16),
+          SessionStatusBanner.fromSession(state),
+          const SizedBox(height: 16),
+          DashboardCalendarCard(
+            summary: dashboard.currentWeekSummary,
+            onOpenCalendar: () => context.goNamed(AppRouteNames.calendar),
+            onReminderTap: () => _handleReminderTap(context, dashboard),
+            reminderTime: dashboard.scheduledReminder,
+            reminderActive: dashboard.hasScheduledReminder,
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Bleib dran: Jede Einheit bringt dich deinem Ziel ein Stück näher.',
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => context.goNamed(
+                    AppRouteNames.training,
+                  ),
+                  child: const Text('Training starten'),
                 ),
-                child: const Text('Training starten'),
               ),
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton(
-                onPressed: () => context.goNamed(AppRouteNames.calendar),
-                child: const Text('Zum Kalender'),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: () => context.goNamed(
+                    AppRouteNames.calendar,
+                    queryParameters: const {'setReminder': 'true'},
+                  ),
+                  child: const Text('Nächstes Training planen'),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  Future<void> _handleReminderTap(
+    BuildContext context,
+    DashboardViewModel dashboard,
+  ) async {
+    if (!dashboard.hasScheduledReminder) {
+      await _pickReminderTime(context, dashboard);
+      return;
+    }
+
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.schedule),
+                title: const Text('Uhrzeit ändern'),
+                onTap: () => Navigator.of(sheetContext).pop('change'),
+              ),
+              ListTile(
+                leading: const Icon(Icons.delete_outline),
+                title: const Text('Reminder entfernen'),
+                onTap: () => Navigator.of(sheetContext).pop('cancel'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (!context.mounted) {
+      return;
+    }
+
+    if (action == 'change') {
+      await _pickReminderTime(context, dashboard);
+    } else if (action == 'cancel') {
+      await dashboard.cancelReminder();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Reminder deaktiviert.')),
+      );
+    }
+  }
+
+  Future<void> _pickReminderTime(
+    BuildContext context,
+    DashboardViewModel dashboard,
+  ) async {
+    final initialTime = dashboard.scheduledReminder ?? const TimeOfDay(hour: 18, minute: 0);
+    final result = await showTimePicker(
+      context: context,
+      initialTime: initialTime,
+      helpText: 'Erinnerung auswählen',
+    );
+    if (result != null) {
+      await dashboard.scheduleReminder(result);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Reminder gesetzt für ${result.format(context)}.'),
+        ),
+      );
+    }
   }
 }

--- a/lib/features/common/state/dashboard_view_model.dart
+++ b/lib/features/common/state/dashboard_view_model.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:free_base/features/calendar/notifier/calendar_notifier.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/services/reminder/reminder_service.dart';
+
+class CalendarWeekSummary {
+  final DateTime weekStart;
+  final int plannedDays;
+  final int completedDays;
+  final bool hasGoldenDay;
+
+  const CalendarWeekSummary({
+    required this.weekStart,
+    required this.plannedDays,
+    required this.completedDays,
+    required this.hasGoldenDay,
+  });
+
+  double get completionRate {
+    if (plannedDays == 0) {
+      return 0;
+    }
+    return completedDays / plannedDays;
+  }
+
+  DateTime get weekEnd => weekStart.add(const Duration(days: 6));
+}
+
+class DashboardViewModel extends ChangeNotifier {
+  static const int _xpPerLevel = 100;
+
+  DashboardViewModel(
+    SessionNotifier sessionNotifier,
+    CalendarNotifier calendarNotifier,
+    ReminderService reminderService,
+  )   : _sessionNotifier = sessionNotifier,
+        _calendarNotifier = calendarNotifier,
+        _reminderService = reminderService {
+    _sessionNotifier.addListener(_sessionListener);
+    _calendarNotifier.addListener(_calendarListener);
+    _reminderService.addListener(_reminderListener);
+  }
+
+  late SessionNotifier _sessionNotifier;
+  late CalendarNotifier _calendarNotifier;
+  late ReminderService _reminderService;
+
+  void updateSources(
+    SessionNotifier sessionNotifier,
+    CalendarNotifier calendarNotifier,
+    ReminderService reminderService,
+  ) {
+    if (!identical(_sessionNotifier, sessionNotifier)) {
+      _sessionNotifier.removeListener(_sessionListener);
+      _sessionNotifier = sessionNotifier;
+      _sessionNotifier.addListener(_sessionListener);
+    }
+    if (!identical(_calendarNotifier, calendarNotifier)) {
+      _calendarNotifier.removeListener(_calendarListener);
+      _calendarNotifier = calendarNotifier;
+      _calendarNotifier.addListener(_calendarListener);
+    }
+    if (!identical(_reminderService, reminderService)) {
+      _reminderService.removeListener(_reminderListener);
+      _reminderService = reminderService;
+      _reminderService.addListener(_reminderListener);
+    }
+    notifyListeners();
+  }
+
+  int get xpTotal => _sessionNotifier.state.xpTotal;
+  int get dailyXp => _sessionNotifier.state.dailyXp;
+  int get streakCount => _sessionNotifier.state.streakCount;
+  DateTime? get streakFrozenUntil => _sessionNotifier.state.streakFrozenUntil;
+
+  bool get freezeAvailable {
+    final until = streakFrozenUntil;
+    if (until == null) {
+      return false;
+    }
+    final today = DateTime.now();
+    final normalized = DateTime(until.year, until.month, until.day);
+    return !today.isAfter(normalized);
+  }
+
+  int get currentLevel => (xpTotal ~/ _xpPerLevel) + 1;
+
+  int get xpIntoLevel => xpTotal % _xpPerLevel;
+
+  int get xpToNextLevel => _xpPerLevel - xpIntoLevel;
+
+  double get levelProgress => xpIntoLevel / _xpPerLevel;
+
+  CalendarWeekSummary get currentWeekSummary => _calculateCurrentWeekSummary();
+
+  TimeOfDay? get scheduledReminder => _reminderService.scheduledTime;
+
+  bool get hasScheduledReminder => _reminderService.hasScheduledReminder;
+
+  Future<void> scheduleReminder(TimeOfDay time) async {
+    await _reminderService.scheduleDailyReminder(time);
+  }
+
+  Future<void> cancelReminder() async {
+    await _reminderService.cancelDailyReminder();
+  }
+
+  CalendarWeekSummary _calculateCurrentWeekSummary() {
+    final now = DateTime.now();
+    final start = now.subtract(Duration(days: now.weekday - DateTime.monday));
+    var plannedDays = 0;
+    var completedDays = 0;
+    var hasGoldenDay = false;
+
+    for (var i = 0; i < 7; i++) {
+      final day = DateTime(start.year, start.month, start.day + i);
+      final events = _calendarNotifier.eventsForDay(day);
+      if (events.isEmpty) {
+        continue;
+      }
+      plannedDays += 1;
+      if (events.any((e) => e.isCompleted)) {
+        completedDays += 1;
+      }
+      if (!hasGoldenDay && events.any((e) => e.isGoldenDay)) {
+        hasGoldenDay = true;
+      }
+    }
+
+    return CalendarWeekSummary(
+      weekStart: DateTime(start.year, start.month, start.day),
+      plannedDays: plannedDays,
+      completedDays: completedDays,
+      hasGoldenDay: hasGoldenDay,
+    );
+  }
+
+  void _sessionListener() {
+    notifyListeners();
+  }
+
+  void _calendarListener() {
+    notifyListeners();
+  }
+
+  void _reminderListener() {
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _sessionNotifier.removeListener(_sessionListener);
+    _calendarNotifier.removeListener(_calendarListener);
+    _reminderService.removeListener(_reminderListener);
+    super.dispose();
+  }
+}

--- a/lib/features/common/widgets/dashboard_calendar_card.dart
+++ b/lib/features/common/widgets/dashboard_calendar_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:free_base/features/common/state/dashboard_view_model.dart';
+
+class DashboardCalendarCard extends StatelessWidget {
+  final CalendarWeekSummary summary;
+  final VoidCallback onOpenCalendar;
+  final VoidCallback onReminderTap;
+  final TimeOfDay? reminderTime;
+  final bool reminderActive;
+
+  const DashboardCalendarCard({
+    super.key,
+    required this.summary,
+    required this.onOpenCalendar,
+    required this.onReminderTap,
+    required this.reminderTime,
+    required this.reminderActive,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final secondaryStyle = theme.textTheme.bodyMedium;
+    final plannedDays = summary.plannedDays;
+    final completedDays = summary.completedDays;
+    final completionText = plannedDays == 0
+        ? 'Noch keine Trainings geplant'
+        : '$completedDays von $plannedDays Tagen abgeschlossen';
+
+    final reminderLabel = reminderActive
+        ? 'Reminder: ${reminderTime?.format(context) ?? ''}'
+        : 'Erinnerung setzen';
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Kalender Woche',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                if (summary.hasGoldenDay)
+                  Chip(
+                    avatar: const Icon(Icons.bug_report_outlined),
+                    label: const Text('Golden Day in Sicht'),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            LinearProgressIndicator(
+              value: summary.completionRate.clamp(0, 1),
+            ),
+            const SizedBox(height: 8),
+            Text(completionText, style: secondaryStyle),
+            const SizedBox(height: 8),
+            Text(
+              'Zeitraum: ${_formatDate(summary.weekStart)} - ${_formatDate(summary.weekEnd)}',
+              style: secondaryStyle,
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              alignment: WrapAlignment.start,
+              children: [
+                FilledButton.icon(
+                  onPressed: onOpenCalendar,
+                  icon: const Icon(Icons.calendar_today_outlined),
+                  label: const Text('Kalender öffnen'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onReminderTap,
+                  icon: const Icon(Icons.alarm),
+                  label: Text(reminderLabel),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) =>
+      '${date.day.toString().padLeft(2, '0')}.'
+      '${date.month.toString().padLeft(2, '0')}.'
+      '${date.year}';
+}

--- a/lib/features/common/widgets/dashboard_header.dart
+++ b/lib/features/common/widgets/dashboard_header.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+class DashboardHeader extends StatelessWidget {
+  final int level;
+  final double levelProgress;
+  final int xpTotal;
+  final int xpToNextLevel;
+  final int streakCount;
+  final bool freezeAvailable;
+  final int dailyXp;
+  final DateTime? freezeUntil;
+
+  const DashboardHeader({
+    super.key,
+    required this.level,
+    required this.levelProgress,
+    required this.xpTotal,
+    required this.xpToNextLevel,
+    required this.streakCount,
+    required this.freezeAvailable,
+    required this.dailyXp,
+    this.freezeUntil,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.titleLarge;
+    final secondaryStyle = theme.textTheme.bodyMedium;
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Level $level', style: titleStyle),
+                      const SizedBox(height: 4),
+                      Text(
+                        '$xpTotal XP gesamt',
+                        style: secondaryStyle,
+                      ),
+                    ],
+                  ),
+                ),
+                Chip(
+                  label: Text('Streak $streakCount'),
+                  avatar: const Icon(Icons.local_fire_department_outlined),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            LinearProgressIndicator(
+              value: levelProgress.clamp(0, 1),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '$xpToNextLevel XP bis zum nächsten Level',
+              style: secondaryStyle,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                Chip(
+                  label: Text('Daily XP: $dailyXp'),
+                  avatar: const Icon(Icons.flash_on_outlined),
+                ),
+                if (freezeAvailable)
+                  Chip(
+                    backgroundColor: theme.colorScheme.secondaryContainer,
+                    avatar: const Icon(Icons.ac_unit),
+                    label: Text(
+                      freezeUntil != null
+                          ? 'Freeze bis ${_formatDate(freezeUntil!)}'
+                          : 'Freeze aktiv',
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final normalized = DateTime(date.year, date.month, date.day);
+    return '${normalized.day}.${normalized.month}.${normalized.year}';
+  }
+}

--- a/lib/features/gamification/models/gamification_state.dart
+++ b/lib/features/gamification/models/gamification_state.dart
@@ -1,0 +1,33 @@
+import 'package:hive/hive.dart';
+
+part 'gamification_state.g.dart';
+
+@HiveType(typeId: 4)
+class GamificationState {
+  const GamificationState({
+    this.level = 1,
+    this.nextThreshold = 100,
+    this.freezeTokens = 0,
+  });
+
+  @HiveField(0)
+  final int level;
+
+  @HiveField(1)
+  final int nextThreshold;
+
+  @HiveField(2)
+  final int freezeTokens;
+
+  GamificationState copyWith({
+    int? level,
+    int? nextThreshold,
+    int? freezeTokens,
+  }) {
+    return GamificationState(
+      level: level ?? this.level,
+      nextThreshold: nextThreshold ?? this.nextThreshold,
+      freezeTokens: freezeTokens ?? this.freezeTokens,
+    );
+  }
+}

--- a/lib/features/gamification/models/gamification_state.g.dart
+++ b/lib/features/gamification/models/gamification_state.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'gamification_state.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class GamificationStateAdapter extends TypeAdapter<GamificationState> {
+  @override
+  final int typeId = 4;
+
+  @override
+  GamificationState read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return GamificationState(
+      level: fields[0] as int? ?? 1,
+      nextThreshold: fields[1] as int? ?? 100,
+      freezeTokens: fields[2] as int? ?? 0,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, GamificationState obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.level)
+      ..writeByte(1)
+      ..write(obj.nextThreshold)
+      ..writeByte(2)
+      ..write(obj.freezeTokens);
+  }
+}

--- a/lib/features/training/models/session_state.dart
+++ b/lib/features/training/models/session_state.dart
@@ -17,6 +17,11 @@ class SessionState with _$SessionState {
     DateTime? plannedFor,
     @Default(SessionStatus.planned) SessionStatus status,
     @Default(false) bool onboardingComplete,
+    @Default(0) int xpTotal,
+    @Default(0) int dailyXp,
+    @Default(0) int streakCount,
+    DateTime? streakFrozenUntil,
+    DateTime? lastCompletedOn,
   }) = _SessionState;
 
   factory SessionState.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/training/models/session_state.freezed.dart
+++ b/lib/features/training/models/session_state.freezed.dart
@@ -30,6 +30,11 @@ mixin _$SessionState {
   DateTime? get plannedFor => throw _privateConstructorUsedError;
   SessionStatus get status => throw _privateConstructorUsedError;
   bool get onboardingComplete => throw _privateConstructorUsedError;
+  int get xpTotal => throw _privateConstructorUsedError;
+  int get dailyXp => throw _privateConstructorUsedError;
+  int get streakCount => throw _privateConstructorUsedError;
+  DateTime? get streakFrozenUntil => throw _privateConstructorUsedError;
+  DateTime? get lastCompletedOn => throw _privateConstructorUsedError;
 
   /// Serializes this SessionState to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -57,7 +62,12 @@ abstract class $SessionStateCopyWith<$Res> {
       DateTime? endAt,
       DateTime? plannedFor,
       SessionStatus status,
-      bool onboardingComplete});
+      bool onboardingComplete,
+      int xpTotal,
+      int dailyXp,
+      int streakCount,
+      DateTime? streakFrozenUntil,
+      DateTime? lastCompletedOn});
 }
 
 /// @nodoc
@@ -85,6 +95,11 @@ class _$SessionStateCopyWithImpl<$Res, $Val extends SessionState>
     Object? plannedFor = freezed,
     Object? status = null,
     Object? onboardingComplete = null,
+    Object? xpTotal = null,
+    Object? dailyXp = null,
+    Object? streakCount = null,
+    Object? streakFrozenUntil = freezed,
+    Object? lastCompletedOn = freezed,
   }) {
     return _then(_value.copyWith(
       phaseId: null == phaseId
@@ -127,6 +142,26 @@ class _$SessionStateCopyWithImpl<$Res, $Val extends SessionState>
           ? _value.onboardingComplete
           : onboardingComplete // ignore: cast_nullable_to_non_nullable
               as bool,
+      xpTotal: null == xpTotal
+          ? _value.xpTotal
+          : xpTotal // ignore: cast_nullable_to_non_nullable
+              as int,
+      dailyXp: null == dailyXp
+          ? _value.dailyXp
+          : dailyXp // ignore: cast_nullable_to_non_nullable
+              as int,
+      streakCount: null == streakCount
+          ? _value.streakCount
+          : streakCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      streakFrozenUntil: freezed == streakFrozenUntil
+          ? _value.streakFrozenUntil
+          : streakFrozenUntil // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      lastCompletedOn: freezed == lastCompletedOn
+          ? _value.lastCompletedOn
+          : lastCompletedOn // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
     ) as $Val);
   }
 }
@@ -175,6 +210,11 @@ class __$$SessionStateImplCopyWithImpl<$Res>
     Object? plannedFor = freezed,
     Object? status = null,
     Object? onboardingComplete = null,
+    Object? xpTotal = null,
+    Object? dailyXp = null,
+    Object? streakCount = null,
+    Object? streakFrozenUntil = freezed,
+    Object? lastCompletedOn = freezed,
   }) {
     return _then(_$SessionStateImpl(
       phaseId: null == phaseId
@@ -217,6 +257,26 @@ class __$$SessionStateImplCopyWithImpl<$Res>
           ? _value.onboardingComplete
           : onboardingComplete // ignore: cast_nullable_to_non_nullable
               as bool,
+      xpTotal: null == xpTotal
+          ? _value.xpTotal
+          : xpTotal // ignore: cast_nullable_to_non_nullable
+              as int,
+      dailyXp: null == dailyXp
+          ? _value.dailyXp
+          : dailyXp // ignore: cast_nullable_to_non_nullable
+              as int,
+      streakCount: null == streakCount
+          ? _value.streakCount
+          : streakCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      streakFrozenUntil: freezed == streakFrozenUntil
+          ? _value.streakFrozenUntil
+          : streakFrozenUntil // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      lastCompletedOn: freezed == lastCompletedOn
+          ? _value.lastCompletedOn
+          : lastCompletedOn // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
     ));
   }
 }
@@ -234,7 +294,12 @@ class _$SessionStateImpl implements _SessionState {
       this.endAt,
       this.plannedFor,
       this.status = SessionStatus.planned,
-      this.onboardingComplete = false});
+      this.onboardingComplete = false,
+      this.xpTotal = 0,
+      this.dailyXp = 0,
+      this.streakCount = 0,
+      this.streakFrozenUntil,
+      this.lastCompletedOn});
 
   factory _$SessionStateImpl.fromJson(Map<String, dynamic> json) =>
       _$$SessionStateImplFromJson(json);
@@ -262,10 +327,23 @@ class _$SessionStateImpl implements _SessionState {
   @override
   @JsonKey()
   final bool onboardingComplete;
+  @override
+  @JsonKey()
+  final int xpTotal;
+  @override
+  @JsonKey()
+  final int dailyXp;
+  @override
+  @JsonKey()
+  final int streakCount;
+  @override
+  final DateTime? streakFrozenUntil;
+  @override
+  final DateTime? lastCompletedOn;
 
   @override
   String toString() {
-    return 'SessionState(phaseId: $phaseId, exerciseIndex: $exerciseIndex, completedReps: $completedReps, remainingSeconds: $remainingSeconds, isPaused: $isPaused, startedAt: $startedAt, endAt: $endAt, plannedFor: $plannedFor, status: $status, onboardingComplete: $onboardingComplete)';
+    return 'SessionState(phaseId: $phaseId, exerciseIndex: $exerciseIndex, completedReps: $completedReps, remainingSeconds: $remainingSeconds, isPaused: $isPaused, startedAt: $startedAt, endAt: $endAt, plannedFor: $plannedFor, status: $status, onboardingComplete: $onboardingComplete, xpTotal: $xpTotal, dailyXp: $dailyXp, streakCount: $streakCount, streakFrozenUntil: $streakFrozenUntil, lastCompletedOn: $lastCompletedOn)';
   }
 
   @override
@@ -289,14 +367,36 @@ class _$SessionStateImpl implements _SessionState {
                 other.plannedFor == plannedFor) &&
             (identical(other.status, status) || other.status == status) &&
             (identical(other.onboardingComplete, onboardingComplete) ||
-                other.onboardingComplete == onboardingComplete));
+                other.onboardingComplete == onboardingComplete) &&
+            (identical(other.xpTotal, xpTotal) || other.xpTotal == xpTotal) &&
+            (identical(other.dailyXp, dailyXp) || other.dailyXp == dailyXp) &&
+            (identical(other.streakCount, streakCount) ||
+                other.streakCount == streakCount) &&
+            (identical(other.streakFrozenUntil, streakFrozenUntil) ||
+                other.streakFrozenUntil == streakFrozenUntil) &&
+            (identical(other.lastCompletedOn, lastCompletedOn) ||
+                other.lastCompletedOn == lastCompletedOn));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, phaseId, exerciseIndex,
-      completedReps, remainingSeconds, isPaused, startedAt, endAt, plannedFor,
-      status, onboardingComplete);
+  int get hashCode => Object.hash(
+      runtimeType,
+      phaseId,
+      exerciseIndex,
+      completedReps,
+      remainingSeconds,
+      isPaused,
+      startedAt,
+      endAt,
+      plannedFor,
+      status,
+      onboardingComplete,
+      xpTotal,
+      dailyXp,
+      streakCount,
+      streakFrozenUntil,
+      lastCompletedOn);
 
   /// Create a copy of SessionState
   /// with the given fields replaced by the non-null parameter values.
@@ -325,7 +425,12 @@ abstract class _SessionState implements SessionState {
       final DateTime? endAt,
       final DateTime? plannedFor,
       final SessionStatus status,
-      final bool onboardingComplete}) = _$SessionStateImpl;
+      final bool onboardingComplete,
+      final int xpTotal,
+      final int dailyXp,
+      final int streakCount,
+      final DateTime? streakFrozenUntil,
+      final DateTime? lastCompletedOn}) = _$SessionStateImpl;
 
   factory _SessionState.fromJson(Map<String, dynamic> json) =
       _$SessionStateImpl.fromJson;
@@ -350,6 +455,16 @@ abstract class _SessionState implements SessionState {
   SessionStatus get status;
   @override
   bool get onboardingComplete;
+  @override
+  int get xpTotal;
+  @override
+  int get dailyXp;
+  @override
+  int get streakCount;
+  @override
+  DateTime? get streakFrozenUntil;
+  @override
+  DateTime? get lastCompletedOn;
 
   /// Create a copy of SessionState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/features/training/models/session_state.g.dart
+++ b/lib/features/training/models/session_state.g.dart
@@ -23,6 +23,15 @@ _$SessionStateImpl _$$SessionStateImplFromJson(Map<String, dynamic> json) =>
       status: $enumDecodeNullable(_$SessionStatusEnumMap, json['status']) ??
           SessionStatus.planned,
       onboardingComplete: json['onboardingComplete'] as bool? ?? false,
+      xpTotal: (json['xpTotal'] as num?)?.toInt() ?? 0,
+      dailyXp: (json['dailyXp'] as num?)?.toInt() ?? 0,
+      streakCount: (json['streakCount'] as num?)?.toInt() ?? 0,
+      streakFrozenUntil: json['streakFrozenUntil'] == null
+          ? null
+          : DateTime.parse(json['streakFrozenUntil'] as String),
+      lastCompletedOn: json['lastCompletedOn'] == null
+          ? null
+          : DateTime.parse(json['lastCompletedOn'] as String),
     );
 
 Map<String, dynamic> _$$SessionStateImplToJson(_$SessionStateImpl instance) =>
@@ -37,6 +46,11 @@ Map<String, dynamic> _$$SessionStateImplToJson(_$SessionStateImpl instance) =>
       'plannedFor': instance.plannedFor?.toIso8601String(),
       'status': _$SessionStatusEnumMap[instance.status]!,
       'onboardingComplete': instance.onboardingComplete,
+      'xpTotal': instance.xpTotal,
+      'dailyXp': instance.dailyXp,
+      'streakCount': instance.streakCount,
+      'streakFrozenUntil': instance.streakFrozenUntil?.toIso8601String(),
+      'lastCompletedOn': instance.lastCompletedOn?.toIso8601String(),
     };
 
 const _$SessionStatusEnumMap = {

--- a/lib/features/training/models/session_state_adapter.dart
+++ b/lib/features/training/models/session_state_adapter.dart
@@ -37,6 +37,11 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
 
     DateTime? plannedFor;
     bool onboardingComplete = false;
+    int xpTotal = 0;
+    int dailyXp = 0;
+    int streakCount = 0;
+    DateTime? streakFrozenUntil;
+    DateTime? lastCompletedOn;
     if (reader.availableBytes > 0) {
       final hasPlannedFor = reader.readBool();
       plannedFor = hasPlannedFor ? reader.read() as DateTime : null;
@@ -44,6 +49,28 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
 
     if (reader.availableBytes > 0) {
       onboardingComplete = reader.readBool();
+    }
+
+    if (reader.availableBytes > 0) {
+      xpTotal = reader.readInt();
+    }
+
+    if (reader.availableBytes > 0) {
+      dailyXp = reader.readInt();
+    }
+
+    if (reader.availableBytes > 0) {
+      streakCount = reader.readInt();
+    }
+
+    if (reader.availableBytes > 0) {
+      final hasFrozenUntil = reader.readBool();
+      streakFrozenUntil = hasFrozenUntil ? reader.read() as DateTime : null;
+    }
+
+    if (reader.availableBytes > 0) {
+      final hasLastCompleted = reader.readBool();
+      lastCompletedOn = hasLastCompleted ? reader.read() as DateTime : null;
     }
 
     return SessionState(
@@ -57,6 +84,11 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
       status: status,
       plannedFor: plannedFor,
       onboardingComplete: onboardingComplete,
+      xpTotal: xpTotal,
+      dailyXp: dailyXp,
+      streakCount: streakCount,
+      streakFrozenUntil: streakFrozenUntil,
+      lastCompletedOn: lastCompletedOn,
     );
   }
 
@@ -86,5 +118,22 @@ class SessionStateAdapter extends TypeAdapter<SessionState> {
     }
 
     writer.writeBool(obj.onboardingComplete);
+    writer.writeInt(obj.xpTotal);
+    writer.writeInt(obj.dailyXp);
+    writer.writeInt(obj.streakCount);
+
+    if (obj.streakFrozenUntil != null) {
+      writer.writeBool(true);
+      writer.write(obj.streakFrozenUntil!);
+    } else {
+      writer.writeBool(false);
+    }
+
+    if (obj.lastCompletedOn != null) {
+      writer.writeBool(true);
+      writer.write(obj.lastCompletedOn!);
+    } else {
+      writer.writeBool(false);
+    }
   }
 }

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -165,9 +165,10 @@ class SessionNotifier extends ChangeNotifier {
       start();
     } else {
       // Session komplett fertig
+      final completionDate = DateTime.now();
       state = state.copyWith(
         status: SessionStatus.completed,
-        endAt: DateTime.now(),
+        endAt: completionDate,
         plannedFor: null,
       );
       // Kalender-Event erstellen statt undefined addSessionEvent
@@ -193,6 +194,7 @@ class SessionNotifier extends ChangeNotifier {
       _calendarService.addEvent(gdEvent);
 
       _markFirstSessionCompleted();
+      applyCompletionRewards(completionDate: completionDate);
     }
   }
 
@@ -228,7 +230,100 @@ class SessionNotifier extends ChangeNotifier {
         state = state.copyWith(status: SessionStatus.overdue);
       }
     }
+    _resetDailyXpIfNeeded();
+    updateStreakFreeze();
   }
+
+  void _resetDailyXpIfNeeded() {
+    final lastCompleted = state.lastCompletedOn;
+    final normalizedToday = _normalizeDate(DateTime.now());
+    if (lastCompleted == null) {
+      if (state.dailyXp != 0) {
+        state = state.copyWith(dailyXp: 0);
+      }
+      return;
+    }
+
+    if (!_isSameDay(lastCompleted, normalizedToday) && state.dailyXp != 0) {
+      state = state.copyWith(dailyXp: 0);
+    }
+  }
+
+  @visibleForTesting
+  int computeXp() {
+    if (_exercises.isEmpty) {
+      return 0;
+    }
+    var xp = 0;
+    for (var i = 0; i < _exercises.length; i++) {
+      final isHighTier = i >= _exercises.length - 2;
+      xp += isHighTier ? 60 : 30;
+    }
+    return xp;
+  }
+
+  @visibleForTesting
+  void applyCompletionRewards({DateTime? completionDate}) {
+    final completion = completionDate ?? DateTime.now();
+    final normalizedCompletion = _normalizeDate(completion);
+    final xpEarned = computeXp();
+    final lastCompleted = state.lastCompletedOn;
+    final wasSameDay =
+        lastCompleted != null && _isSameDay(lastCompleted, normalizedCompletion);
+    final wasConsecutive = lastCompleted != null &&
+        normalizedCompletion.difference(lastCompleted).inDays == 1;
+    final freezeUntil = state.streakFrozenUntil != null
+        ? _normalizeDate(state.streakFrozenUntil!)
+        : null;
+
+    final newDailyXp = wasSameDay ? state.dailyXp + xpEarned : xpEarned;
+
+    int newStreakCount;
+    if (wasSameDay) {
+      newStreakCount = state.streakCount;
+    } else if (wasConsecutive) {
+      newStreakCount = state.streakCount + 1;
+    } else if (freezeUntil != null &&
+        !normalizedCompletion.isAfter(freezeUntil)) {
+      newStreakCount = state.streakCount;
+    } else {
+      newStreakCount = 1;
+    }
+
+    state = state.copyWith(
+      xpTotal: state.xpTotal + xpEarned,
+      dailyXp: newDailyXp,
+      streakCount: newStreakCount,
+      lastCompletedOn: normalizedCompletion,
+    );
+
+    updateStreakFreeze(referenceDate: normalizedCompletion);
+  }
+
+  void updateStreakFreeze({DateTime? referenceDate}) {
+    final today = _normalizeDate(referenceDate ?? DateTime.now());
+    final freezeUntil = state.streakFrozenUntil;
+    if (freezeUntil != null) {
+      final normalizedFreeze = _normalizeDate(freezeUntil);
+      if (today.isAfter(normalizedFreeze)) {
+        state = state.copyWith(streakFrozenUntil: null);
+      }
+    }
+
+    if (state.streakCount >= 2 && state.streakFrozenUntil == null) {
+      final baseDate =
+          _normalizeDate(referenceDate ?? state.lastCompletedOn ?? DateTime.now());
+      state = state.copyWith(
+        streakFrozenUntil: baseDate.add(const Duration(days: 1)),
+      );
+    }
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  DateTime _normalizeDate(DateTime date) =>
+      DateTime(date.year, date.month, date.day);
 
   void _markFirstSessionCompleted() {
     final user = FirebaseAuth.instance.currentUser;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,8 +27,10 @@ import 'package:free_base/features/training/widgets/session_sync_listener.dart';
 
 import 'package:free_base/features/calendar/models/calendar_event.dart';
 import 'package:free_base/features/calendar/models/calendar_event_adapter.dart';
+import 'package:free_base/features/calendar/notifier/calendar_notifier.dart';
 import 'package:free_base/features/calendar/services/calendar_service.dart';
 import 'package:free_base/features/calendar/services/golden_day_service.dart';
+import 'package:free_base/features/common/state/dashboard_view_model.dart';
 import 'package:free_base/features/questionnaire/questionnaire_screen.dart';
 import 'package:free_base/services/app_intent_handler.dart';
 import 'package:free_base/services/app_route_guard.dart';
@@ -37,6 +39,8 @@ import 'package:free_base/services/feature_flags.dart';
 import 'package:free_base/services/telemetry/telemetry_service.dart';
 
 import 'package:free_base/features/onboarding/models/consent_state.dart';
+import 'package:free_base/features/gamification/models/gamification_state.dart';
+import 'package:free_base/services/reminder/reminder_service.dart';
 
 const FeatureFlags _localFeatureFlags = FeatureFlags(
   parentsTrackEnabled: true,
@@ -85,6 +89,7 @@ Future<void> main() async {
   Hive.registerAdapter(SessionStatusAdapter());
   Hive.registerAdapter(SessionStateAdapter());
   Hive.registerAdapter(ConsentStateAdapter());
+  Hive.registerAdapter(GamificationStateAdapter());
   await Hive.openBox<SessionState>('session_state',
       encryptionCipher: HiveAesCipher(encryptionKey));
 
@@ -96,6 +101,9 @@ Future<void> main() async {
 
   Hive.registerAdapter(CalendarEventAdapter());
   await Hive.openBox<CalendarEvent>('calendar_events',
+      encryptionCipher: HiveAesCipher(encryptionKey));
+
+  await Hive.openBox<GamificationState>('gamification_state',
       encryptionCipher: HiveAesCipher(encryptionKey));
 
   final sessionRepository = SessionRepository();
@@ -220,6 +228,13 @@ class _MyAppState extends State<MyApp> {
         Provider<ExerciseRepository>(
           create: (_) => ExerciseRepository(),
         ),
+        ChangeNotifierProvider<ReminderService>(
+          create: (_) {
+            final service = ReminderService();
+            unawaited(service.initialize());
+            return service;
+          },
+        ),
         ChangeNotifierProvider<SessionNotifier>(
           create: (ctx) {
             final exRepo = ctx.read<ExerciseRepository>();
@@ -234,6 +249,27 @@ class _MyAppState extends State<MyApp> {
               initialExercises,
               widget.initialSessionState,
             );
+          },
+        ),
+        ChangeNotifierProvider<CalendarNotifier>(
+          create: (ctx) {
+            final notifier = CalendarNotifier(ctx.read<CalendarService>());
+            notifier.loadMonth(DateTime.now());
+            return notifier;
+          },
+        ),
+        ChangeNotifierProxyProvider3<SessionNotifier, CalendarNotifier,
+            ReminderService, DashboardViewModel>(
+          create: (ctx) => DashboardViewModel(
+            ctx.read<SessionNotifier>(),
+            ctx.read<CalendarNotifier>(),
+            ctx.read<ReminderService>(),
+          ),
+          update: (ctx, session, calendar, reminder, previous) {
+            final model = previous ??
+                DashboardViewModel(session, calendar, reminder);
+            model.updateSources(session, calendar, reminder);
+            return model;
           },
         ),
         createQuestionnaireProvider(),

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -112,7 +112,11 @@ class AppRouter {
               GoRoute(
                 path: AppRoutePaths.calendar,
                 name: AppRouteNames.calendar,
-                builder: (context, state) => const CalendarScreen(),
+                builder: (context, state) {
+                  final openReminder =
+                      state.uri.queryParameters['setReminder'] == 'true';
+                  return CalendarScreen(openReminder: openReminder);
+                },
               ),
             ],
           ),

--- a/lib/services/reminder/reminder_service.dart
+++ b/lib/services/reminder/reminder_service.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+/// ReminderService
+///
+/// Initialisiert `flutter_local_notifications` und stellt Methoden zur
+/// Verfügung, um tägliche Erinnerungen für das Training zu planen oder
+/// wieder zu löschen.
+class ReminderService extends ChangeNotifier {
+  ReminderService({FlutterLocalNotificationsPlugin? plugin})
+      : _notifications = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _notifications;
+  bool _initialized = false;
+  bool _timeZonesInitialized = false;
+  TimeOfDay? _scheduledTime;
+
+  TimeOfDay? get scheduledTime => _scheduledTime;
+  bool get hasScheduledReminder => _scheduledTime != null;
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    final androidSettings = const AndroidInitializationSettings('@mipmap/ic_launcher');
+    final iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+    final initializationSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+    await _notifications.initialize(initializationSettings);
+    _initialized = true;
+  }
+
+  Future<void> scheduleDailyReminder(TimeOfDay time) async {
+    await initialize();
+    _ensureTimeZones();
+    final scheduleDate = _nextInstance(time);
+    const androidDetails = AndroidNotificationDetails(
+      'training_reminders',
+      'Trainingserinnerungen',
+      channelDescription: 'Lokale Erinnerung für tägliche Trainingseinheiten.',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    final details = NotificationDetails(android: androidDetails, iOS: iosDetails);
+
+    await _notifications.zonedSchedule(
+      1000,
+      'Zeit für dein Training',
+      'Plane jetzt deine nächste Einheit.',
+      scheduleDate,
+      details,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+    _scheduledTime = time;
+    notifyListeners();
+  }
+
+  Future<void> cancelDailyReminder() async {
+    await initialize();
+    await _notifications.cancel(1000);
+    if (_scheduledTime != null) {
+      _scheduledTime = null;
+      notifyListeners();
+    }
+  }
+
+  void _ensureTimeZones() {
+    if (_timeZonesInitialized) {
+      return;
+    }
+    tz.initializeTimeZones();
+    _timeZonesInitialized = true;
+  }
+
+  tz.TZDateTime _nextInstance(TimeOfDay time) {
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduled = tz.TZDateTime(
+      tz.local,
+      now.year,
+      now.month,
+      now.day,
+      time.hour,
+      time.minute,
+    );
+    if (scheduled.isBefore(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+    return scheduled;
+  }
+}

--- a/test/features/training/session_notifier_xp_test.dart
+++ b/test/features/training/session_notifier_xp_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:free_base/features/calendar/models/calendar_event.dart';
+import 'package:free_base/features/calendar/services/calendar_service.dart';
+import 'package:free_base/features/calendar/services/golden_day_service.dart';
+import 'package:free_base/features/training/models/exercise_item.dart';
+import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/training/services/session_repository.dart';
+import 'package:free_base/features/training/services/sync_service.dart';
+
+class _TestSessionRepository extends SessionRepository {
+  SessionState? saved;
+
+  @override
+  Future<SessionState?> load() async => saved;
+
+  @override
+  Future<void> save(SessionState state) async {
+    saved = state;
+  }
+
+  @override
+  Future<void> clear() async {
+    saved = null;
+  }
+}
+
+class _TestSyncService implements SyncService {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> enqueue(SessionState state) async {}
+
+  @override
+  Stream<SyncStatusEvent> get statusStream => Stream<SyncStatusEvent>.empty();
+}
+
+class _TestCalendarService implements CalendarService {
+  final List<CalendarEvent> addedEvents = [];
+
+  @override
+  Future<void> addEvent(CalendarEvent event) async {
+    addedEvents.add(event);
+  }
+
+  @override
+  Future<void> removeEvent(String id) async {}
+
+  @override
+  Future<List<CalendarEvent>> loadEventsForMonth(DateTime month) async =>
+      const <CalendarEvent>[];
+
+  @override
+  Future<void> saveTrainingDay(CalendarEvent event) async {}
+
+  @override
+  Future<DateTime?> loadUpcomingGoldenDay() async => null;
+}
+
+class _TestExerciseRepository extends ExerciseRepository {
+  _TestExerciseRepository(this.items);
+
+  final List<ExerciseItem> items;
+
+  @override
+  List<ExerciseItem> getExercisesForPhase(String phaseId) => items;
+}
+
+SessionNotifier _createNotifier({DateTime? plannedFor}) {
+  final exercises = List.generate(7, (i) {
+    final index = i + 1;
+    return ExerciseItem(
+      id: '0-$index',
+      name: 'Übung $index',
+      imagePath: 'placeholder',
+      activeSeconds: 8,
+      restSeconds: 4,
+      repetitions: 1,
+    );
+  });
+  final exerciseRepo = _TestExerciseRepository(exercises);
+  final sessionRepository = _TestSessionRepository();
+  final calendarService = _TestCalendarService();
+  final notifier = SessionNotifier(
+    sessionRepository,
+    _TestSyncService(),
+    calendarService,
+    GoldenDayService(),
+    exerciseRepo,
+    exercises,
+    SessionState(
+      phaseId: '0',
+      exerciseIndex: 0,
+      completedReps: 0,
+      remainingSeconds: exercises.first.activeSeconds,
+      isPaused: true,
+      startedAt: plannedFor ?? DateTime(2024, 1, 1),
+      plannedFor: plannedFor ?? DateTime(2024, 1, 1),
+      status: SessionStatus.planned,
+    ),
+  );
+  return notifier;
+}
+
+void main() {
+  group('SessionNotifier gamification', () {
+    test('computeXp returns combined xp for exercises', () {
+      final notifier = _createNotifier();
+      expect(notifier.computeXp(), 30 * 5 + 60 * 2);
+    });
+
+    test('applyCompletionRewards increases xp and streak', () {
+      final notifier = _createNotifier();
+      final yesterday = DateTime(2024, 1, 1);
+      notifier.state = notifier.state.copyWith(
+        xpTotal: 90,
+        dailyXp: 0,
+        streakCount: 1,
+        lastCompletedOn: yesterday,
+      );
+
+      final completion = DateTime(2024, 1, 2, 8);
+      notifier.applyCompletionRewards(completionDate: completion);
+
+      expect(notifier.state.xpTotal, 90 + notifier.computeXp());
+      expect(notifier.state.dailyXp, notifier.computeXp());
+      expect(notifier.state.streakCount, 2);
+      expect(notifier.state.streakFrozenUntil, isNotNull);
+    });
+
+    test('refreshScheduleStatus resets daily xp and clears expired freeze', () {
+      final notifier = _createNotifier(plannedFor: DateTime.now().add(const Duration(days: 1)));
+      final last = DateTime.now().subtract(const Duration(days: 2));
+      notifier.state = notifier.state.copyWith(
+        dailyXp: 120,
+        lastCompletedOn: DateTime(last.year, last.month, last.day),
+        streakFrozenUntil: DateTime.now().subtract(const Duration(days: 1)),
+        streakCount: 3,
+        status: SessionStatus.planned,
+        plannedFor: DateTime.now().add(const Duration(days: 1)),
+      );
+
+      notifier.refreshScheduleStatus();
+
+      expect(notifier.state.dailyXp, 0);
+      expect(notifier.state.streakFrozenUntil, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extend the persisted session state and Hive adapter with XP and streak metadata plus a gamification Hive model for future progression features【F:lib/features/training/models/session_state.dart†L10-L25】【F:lib/features/training/models/session_state_adapter.dart†L40-L138】【F:lib/features/gamification/models/gamification_state.dart†L5-L33】
- enrich the session notifier with XP/streak calculations and expose aggregated dashboard data through a dedicated view model and refreshed header/calendar widgets【F:lib/features/training/notifier/session_notifier.dart†L168-L318】【F:lib/features/common/state/dashboard_view_model.dart†L32-L156】【F:lib/features/common/dashboard_screen.dart†L51-L184】
- introduce a local reminder service, wire calendar reminder affordances, and cover the new XP logic with unit tests【F:lib/services/reminder/reminder_service.dart†L13-L102】【F:lib/features/calendar/screens/calendar_screen.dart†L33-L175】【F:test/features/training/session_notifier_xp_test.dart†L107-L149】

## Testing
- Tests not run (flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_69049b72144c832da286169152163795