### PR TITLE
Fix analyzer warnings across reminder and training flows

### DIFF
--- a/lib/features/calendar/screens/calendar_screen.dart
+++ b/lib/features/calendar/screens/calendar_screen.dart
@@ -12,7 +12,6 @@ import 'package:free_base/services/reminder/reminder_service.dart';
 import '../dialogs/edit_training_day_dialog.dart';
 import '../models/calendar_event.dart';
 import '../notifier/calendar_notifier.dart';
-import '../services/calendar_service.dart';
 import '../widgets/golden_day_banner.dart';
 import '../widgets/level_map_calendar.dart';
 import '../widgets/month_bracket.dart';
@@ -116,7 +115,7 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
       },
     );
 
-    if (!mounted) return;
+    if (!context.mounted) return;
 
     if (action == 'change') {
       await _pickReminderTime(reminderService);
@@ -137,7 +136,7 @@ class _CalendarScreenContentState extends State<_CalendarScreenContent> {
     );
     if (result != null) {
       await service.scheduleDailyReminder(result);
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Reminder gesetzt für ${result.format(context)}.'),

--- a/lib/features/onboarding/screens/consent_screen.dart
+++ b/lib/features/onboarding/screens/consent_screen.dart
@@ -34,15 +34,15 @@ class _ConsentScreenState extends State<ConsentScreen> {
   Future<void> _acceptConsent() async {
     final locale = Localizations.maybeLocaleOf(context)?.toLanguageTag() ?? 'de';
     final consentNotifier = context.read<ConsentNotifier>();
-    await consentNotifier.accept(locale: locale);
-
     final telemetry = context.read<TelemetryService>();
+    final featureFlags = context.read<FeatureFlags>();
+
+    await consentNotifier.accept(locale: locale);
     await telemetry.logEvent('consent_accepted', properties: {
       'locale': locale,
     });
 
-    if (!mounted) return;
-    final featureFlags = context.read<FeatureFlags>();
+    if (!context.mounted) return;
     final targetRoute = featureFlags.consentRequired
         ? AppRouteNames.dashboard
         : AppRouteNames.training;
@@ -75,6 +75,12 @@ class _ConsentScreenState extends State<ConsentScreen> {
       message: isGerman
           ? 'Um Corejourney zu nutzen, benötigen wir deine Zustimmung zur vorläufigen Datenschutzerklärung. Die finalen Texte folgen in einer späteren Version.'
           : 'To continue using Corejourney you need to accept the placeholder privacy agreement. The final copy will arrive in a future update.',
+      primaryActionLabel:
+          isGerman ? 'Zustimmen und fortfahren' : 'Accept and continue',
+      onPrimaryAction: _acceptConsent,
+      secondaryActionLabel: isGerman ? 'Ablehnen' : 'Decline',
+      onSecondaryAction: _showDeclineInfo,
+      icon: Icons.privacy_tip_outlined,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -100,12 +106,6 @@ class _ConsentScreenState extends State<ConsentScreen> {
           ),
         ],
       ),
-      primaryActionLabel:
-          isGerman ? 'Zustimmen und fortfahren' : 'Accept and continue',
-      onPrimaryAction: _acceptConsent,
-      secondaryActionLabel: isGerman ? 'Ablehnen' : 'Decline',
-      onSecondaryAction: _showDeclineInfo,
-      icon: Icons.privacy_tip_outlined,
     );
   }
 }

--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -59,14 +59,14 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
   Future<void> _save(BuildContext context, String name) async {
     setState(() => _isSaving = true);
     final trimmed = name.trim().isEmpty ? 'Reflexprofil' : name.trim();
+    final questionnaireState = context.read<QuestionnaireState>();
+    final sessionNotifier = context.read<SessionNotifier>();
+    final telemetry = context.read<TelemetryService>();
+    final featureFlags = context.read<FeatureFlags>();
     try {
-      await context
-          .read<QuestionnaireState>()
-          .saveResult(name: trimmed, context: context);
+      await questionnaireState.saveResult(name: trimmed, context: context);
 
-      context.read<SessionNotifier>().markOnboardingComplete();
-      final telemetry = context.read<TelemetryService>();
-      final featureFlags = context.read<FeatureFlags>();
+      sessionNotifier.markOnboardingComplete();
       final locale = Localizations.maybeLocaleOf(context)?.toLanguageTag() ?? 'de';
       await telemetry.logEvent('onboarding_complete', properties: {
         'locale': locale,

--- a/lib/features/training/models/session_state.freezed.dart
+++ b/lib/features/training/models/session_state.freezed.dart
@@ -184,7 +184,12 @@ abstract class _$$SessionStateImplCopyWith<$Res>
       DateTime? endAt,
       DateTime? plannedFor,
       SessionStatus status,
-      bool onboardingComplete});
+      bool onboardingComplete,
+      int xpTotal,
+      int dailyXp,
+      int streakCount,
+      DateTime? streakFrozenUntil,
+      DateTime? lastCompletedOn});
 }
 
 /// @nodoc

--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -88,10 +88,9 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
     super.dispose();
   }
 
-  Future<bool> _handleWillPop() async {
+  Future<void> _handleWillPop() async {
     _cancelTimer();
     Navigator.of(context).pop(const MoroExerciseResult(completed: false));
-    return false;
   }
 
   void _cancelTimer() {
@@ -481,8 +480,14 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
   @override
   Widget build(BuildContext context) {
     final ex = widget.exercise;
-    return WillPopScope(
-      onWillPop: _handleWillPop,
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) {
+          return;
+        }
+        await _handleWillPop();
+      },
       child: Scaffold(
         appBar: AppBar(
           title: Text(ex.title),

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -118,7 +118,7 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
                                     ),
                                     Chip(
                                       label: Text(lockLabel),
-                                      backgroundColor: lockColor.withOpacity(0.1),
+                                      backgroundColor: lockColor.withAlpha(26),
                                       labelStyle: TextStyle(color: labelColor),
                                     ),
                                   ],
@@ -203,7 +203,7 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
         offset: offset,
       ),
     );
-    if (!mounted) return;
+    if (!context.mounted) return;
     if (result is MoroExerciseResult && result.completed) {
       await MoroProgressStore.markCompleted(ex.index, totalExercises);
       await _refreshProgress(totalExercises);
@@ -217,7 +217,7 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
         context,
         summary: summary,
       );
-      if (!mounted) return;
+      if (!context.mounted) return;
       switch (action) {
         case SessionCompletionAction.openCalendar:
           context.goNamed(AppRouteNames.calendar);

--- a/lib/features/training/widgets/session_status_banner.dart
+++ b/lib/features/training/widgets/session_status_banner.dart
@@ -58,7 +58,6 @@ class SessionStatusBanner extends StatelessWidget {
       case SessionStatusBannerState.overdue:
         return 'Session überfällig';
       case SessionStatusBannerState.planned:
-      default:
         return 'Session geplant';
     }
   }
@@ -78,7 +77,6 @@ class SessionStatusBanner extends StatelessWidget {
         }
         return 'Starte deine Session, um wieder im Plan zu sein.';
       case SessionStatusBannerState.planned:
-      default:
         if (plannedFor != null) {
           if (plannedFor.isAfter(DateTime.now())) {
             return 'Geplant für ${DateFormat.yMMMMd().format(plannedFor)}';
@@ -92,12 +90,11 @@ class SessionStatusBanner extends StatelessWidget {
   Color _backgroundColor(BuildContext context) {
     switch (status) {
       case SessionStatusBannerState.inProgress:
-        return Theme.of(context).colorScheme.primary.withOpacity(0.12);
+        return Theme.of(context).colorScheme.primary.withAlpha(31);
       case SessionStatusBannerState.overdue:
-        return Theme.of(context).colorScheme.error.withOpacity(0.12);
+        return Theme.of(context).colorScheme.error.withAlpha(31);
       case SessionStatusBannerState.planned:
-      default:
-        return Theme.of(context).colorScheme.secondary.withOpacity(0.12);
+        return Theme.of(context).colorScheme.secondary.withAlpha(31);
     }
   }
 
@@ -108,7 +105,6 @@ class SessionStatusBanner extends StatelessWidget {
       case SessionStatusBannerState.overdue:
         return Theme.of(context).colorScheme.error;
       case SessionStatusBannerState.planned:
-      default:
         return Theme.of(context).colorScheme.secondary;
     }
   }
@@ -120,7 +116,6 @@ class SessionStatusBanner extends StatelessWidget {
       case SessionStatusBannerState.overdue:
         return Icons.warning_amber_rounded;
       case SessionStatusBannerState.planned:
-      default:
         return Icons.schedule;
     }
   }

--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -31,8 +31,7 @@ class AppRouter {
   AppRouter({
     required Listenable refreshListenable,
     required AppRouteGuard guard,
-  })  : _guard = guard,
-        router = GoRouter(
+  })  : router = GoRouter(
           navigatorKey: _rootNavigatorKey,
           initialLocation: AppRoutePaths.splash,
           refreshListenable: refreshListenable,
@@ -46,7 +45,6 @@ class AppRouter {
   static final _trainingNavigatorKey = GlobalKey<NavigatorState>();
   static final _profileNavigatorKey = GlobalKey<NavigatorState>();
 
-  final AppRouteGuard _guard;
   final GoRouter router;
 
   static List<RouteBase> _buildRoutes() {

--- a/lib/services/error_handler.dart
+++ b/lib/services/error_handler.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/services/reminder/reminder_service.dart
+++ b/lib/services/reminder/reminder_service.dart
@@ -61,7 +61,6 @@ class ReminderService extends ChangeNotifier {
       scheduleDate,
       details,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.time,
     );
     _scheduledTime = time;

--- a/lib/widgets/info_card.dart
+++ b/lib/widgets/info_card.dart
@@ -19,7 +19,7 @@ class InfoCard extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceVariant.withOpacity(0.5),
+        color: theme.colorScheme.surfaceContainerHighest.withAlpha(128),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: theme.colorScheme.outlineVariant,


### PR DESCRIPTION
## Summary
- guard reminder, consent, and questionnaire flows with context.mounted checks and pre-read dependencies to avoid analyzer errors
- repair the Freezed copyWith signature for SessionState so gamification fields compile
- replace deprecated APIs across training widgets, reminder scheduling, and shared UI colors

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6904a04c1008832da7dd823af460a6f2