### PR TITLE
Add reflex profile shop and visualization

### DIFF
--- a/lib/features/profile/mappers/reflex_score_mapper.dart
+++ b/lib/features/profile/mappers/reflex_score_mapper.dart
@@ -1,0 +1,46 @@
+class ReflexScoreViewModel {
+  ReflexScoreViewModel({
+    required this.reflexName,
+    required this.yesCount,
+    required this.totalCount,
+  });
+
+  final String reflexName;
+  final int yesCount;
+  final int totalCount;
+
+  double get ratio => totalCount == 0 ? 0 : yesCount / totalCount;
+  int get percentage => (ratio * 100).round();
+}
+
+class ReflexScoreMapper {
+  static List<ReflexScoreViewModel> fromSummary(
+    Map<String, List<int>> summary,
+  ) {
+    return summary.entries
+        .map(
+          (entry) => ReflexScoreViewModel(
+            reflexName: entry.key,
+            yesCount: entry.value.isNotEmpty ? entry.value.first : 0,
+            totalCount: entry.value.length > 1 ? entry.value[1] : 0,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => a.reflexName.compareTo(b.reflexName));
+  }
+
+  static List<ReflexScoreViewModel> fromStoredScores(
+    Map<String, dynamic> scores,
+  ) {
+    return scores.entries
+        .map(
+          (entry) => ReflexScoreViewModel(
+            reflexName: entry.key,
+            yesCount: (entry.value['yes'] as num?)?.round() ?? 0,
+            totalCount: (entry.value['total'] as num?)?.round() ?? 0,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => a.reflexName.compareTo(b.reflexName));
+  }
+}

--- a/lib/features/profile/models/cosmetic_item.dart
+++ b/lib/features/profile/models/cosmetic_item.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+enum CosmeticRarity { common, rare, epic, legendary }
+
+CosmeticRarity cosmeticRarityFromString(String? value) {
+  switch (value?.toLowerCase()) {
+    case 'rare':
+      return CosmeticRarity.rare;
+    case 'epic':
+      return CosmeticRarity.epic;
+    case 'legendary':
+      return CosmeticRarity.legendary;
+    default:
+      return CosmeticRarity.common;
+  }
+}
+
+String cosmeticRarityToString(CosmeticRarity rarity) {
+  switch (rarity) {
+    case CosmeticRarity.rare:
+      return 'rare';
+    case CosmeticRarity.epic:
+      return 'epic';
+    case CosmeticRarity.legendary:
+      return 'legendary';
+    case CosmeticRarity.common:
+      return 'common';
+  }
+}
+
+Color rarityColor(CosmeticRarity rarity, {Brightness brightness = Brightness.light}) {
+  switch (rarity) {
+    case CosmeticRarity.common:
+      return brightness == Brightness.dark
+          ? Colors.blueGrey.shade200
+          : Colors.blueGrey.shade400;
+    case CosmeticRarity.rare:
+      return brightness == Brightness.dark ? Colors.indigo.shade200 : Colors.indigo;
+    case CosmeticRarity.epic:
+      return brightness == Brightness.dark ? Colors.purpleAccent.shade100 : Colors.purple;
+    case CosmeticRarity.legendary:
+      return brightness == Brightness.dark ? Colors.amberAccent.shade100 : Colors.amber;
+  }
+}
+
+class CosmeticItem {
+  CosmeticItem({
+    required this.id,
+    required this.name,
+    required this.priceXp,
+    required this.assetPath,
+    required this.rarity,
+  });
+
+  final String id;
+  final String name;
+  final int priceXp;
+  final String assetPath;
+  final CosmeticRarity rarity;
+
+  factory CosmeticItem.fromMap(Map<String, dynamic> data, String id) {
+    return CosmeticItem(
+      id: id,
+      name: data['name'] as String? ?? 'Kosmetik',
+      priceXp: (data['priceXp'] as num?)?.round() ?? 0,
+      assetPath: data['assetPath'] as String? ?? '',
+      rarity: cosmeticRarityFromString(data['rarity'] as String?),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'name': name,
+        'priceXp': priceXp,
+        'assetPath': assetPath,
+        'rarity': cosmeticRarityToString(rarity),
+      };
+
+  Map<String, dynamic> toCache() => {
+        'id': id,
+        ...toMap(),
+      };
+}

--- a/lib/features/profile/models/cosmetic_purchase.dart
+++ b/lib/features/profile/models/cosmetic_purchase.dart
@@ -1,0 +1,39 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class CosmeticPurchase {
+  CosmeticPurchase({
+    required this.id,
+    required this.profileId,
+    required this.itemId,
+    required this.unlockedAt,
+  });
+
+  final String id;
+  final String profileId;
+  final String itemId;
+  final DateTime unlockedAt;
+
+  factory CosmeticPurchase.fromMap(Map<String, dynamic> data, String id) {
+    final timestamp = data['unlockedAt'];
+    DateTime unlockedAt;
+    if (timestamp is Timestamp) {
+      unlockedAt = timestamp.toDate();
+    } else if (timestamp is DateTime) {
+      unlockedAt = timestamp;
+    } else {
+      unlockedAt = DateTime.now();
+    }
+    return CosmeticPurchase(
+      id: id,
+      profileId: data['profileId'] as String? ?? '',
+      itemId: data['itemId'] as String? ?? '',
+      unlockedAt: unlockedAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'profileId': profileId,
+        'itemId': itemId,
+        'unlockedAt': Timestamp.fromDate(unlockedAt),
+      };
+}

--- a/lib/features/profile/models/reflex_profile.dart
+++ b/lib/features/profile/models/reflex_profile.dart
@@ -8,6 +8,9 @@ class ReflexProfile {
   final bool isMainProfile;
   final Map<String, dynamic> reflexScores;
   final Map<String, String> answers;
+  final String? avatarItemId;
+  final int xpSpent;
+  final String questionnaireVersion;
 
   ReflexProfile({
     required this.id,
@@ -17,6 +20,9 @@ class ReflexProfile {
     required this.isMainProfile,
     required this.reflexScores,
     required this.answers,
+    this.avatarItemId,
+    this.xpSpent = 0,
+    this.questionnaireVersion = 'v1',
   });
 
   factory ReflexProfile.fromMap(Map<String, dynamic> data, String docId) {
@@ -28,6 +34,10 @@ class ReflexProfile {
       isMainProfile: data['isMainProfile'] as bool? ?? false,
       reflexScores: Map<String, dynamic>.from(data['reflexScores'] ?? {}),
       answers: Map<String, String>.from(data['answers'] ?? {}),
+      avatarItemId: data['avatarItemId'] as String?,
+      xpSpent: (data['xpSpent'] as num?)?.round() ?? 0,
+      questionnaireVersion:
+          data['questionnaireVersion'] as String? ?? 'v1',
     );
   }
 
@@ -38,5 +48,8 @@ class ReflexProfile {
         'isMainProfile': isMainProfile,
         'reflexScores': reflexScores,
         'answers': answers,
+        'avatarItemId': avatarItemId,
+        'xpSpent': xpSpent,
+        'questionnaireVersion': questionnaireVersion,
       };
 }

--- a/lib/features/profile/screens/profile_overview_screen.dart
+++ b/lib/features/profile/screens/profile_overview_screen.dart
@@ -14,6 +14,29 @@ import '../services/profile_service.dart';
 class ProfileOverviewScreen extends StatelessWidget {
   const ProfileOverviewScreen({super.key});
 
+  Color _avatarColor(String? itemId, ThemeData theme) {
+    if (itemId == null || itemId.isEmpty) {
+      return theme.colorScheme.secondary.withOpacity(0.2);
+    }
+    final hash = itemId.codeUnits.fold<int>(0, (acc, code) => acc + code);
+    final hue = (hash % 360).toDouble();
+    return HSVColor.fromAHSV(1, hue, 0.4, 0.8).toColor();
+  }
+
+  Widget _buildAvatarPreview(ReflexProfile profile, ThemeData theme, {double radius = 24}) {
+    final color = _avatarColor(profile.avatarItemId, theme);
+    final brightness = ThemeData.estimateBrightnessForColor(color);
+    final iconColor = brightness == Brightness.dark ? Colors.white : Colors.black87;
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: color,
+      child: Icon(
+        Icons.person,
+        color: iconColor,
+      ),
+    );
+  }
+
   Future<void> _deleteProfile(BuildContext context, String userId, String profileId, bool isMain) async {
     final confirm = await showDialog<bool>(
       context: context,
@@ -68,6 +91,16 @@ class ProfileOverviewScreen extends StatelessWidget {
             final profiles = snap.data!;
             final showCommunityLinks =
                 flags.forumEnabled || flags.achievementsEnabled;
+            final theme = Theme.of(context);
+            ReflexProfile? mainProfile;
+            if (mainId != null) {
+              try {
+                mainProfile = profiles.firstWhere((p) => p.id == mainId);
+              } catch (_) {
+                mainProfile = profiles.isNotEmpty ? profiles.first : null;
+              }
+            }
+            mainProfile ??= profiles.isNotEmpty ? profiles.first : null;
             return Scaffold(
               appBar: AppBar(
                 title: const Text('Reflexprofile'),
@@ -89,10 +122,24 @@ class ProfileOverviewScreen extends StatelessWidget {
                             itemBuilder: (ctx, i) {
                               final p = profiles[i];
                               final isMain = p.id == mainId;
+                              final preview = _buildAvatarPreview(p, theme);
                               return ListTile(
-                                leading: isMain
-                                    ? const Icon(Icons.star, color: Colors.orange)
-                                    : const Icon(Icons.person),
+                                leading: Stack(
+                                  alignment: Alignment.bottomRight,
+                                  children: [
+                                    preview,
+                                    if (isMain)
+                                      const Positioned(
+                                        right: -2,
+                                        bottom: -2,
+                                        child: Icon(
+                                          Icons.star,
+                                          color: Colors.orange,
+                                          size: 16,
+                                        ),
+                                      ),
+                                  ],
+                                ),
                                 title: Text(p.name),
                                 subtitle: Text(DateFormat('dd.MM.yyyy').format(p.createdAt)),
                                 onTap: () => context.pushNamed(
@@ -105,17 +152,60 @@ class ProfileOverviewScreen extends StatelessWidget {
                                         .withAlpha((0.2 * 255).round())
                                     : null,
 
-                                trailing: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
+                                trailing: PopupMenuButton<_ProfileAction>(
+                                  onSelected: (action) async {
+                                    switch (action) {
+                                      case _ProfileAction.setMain:
+                                        final confirm = await showDialog<bool>(
+                                          context: context,
+                                          builder: (ctx) => AlertDialog(
+                                            title: const Text('Profil wechseln?'),
+                                            content: Text(
+                                                'Möchtest du "${p.name}" als aktives Profil nutzen?'),
+                                            actions: [
+                                              TextButton(
+                                                onPressed: () => Navigator.pop(ctx, false),
+                                                child: const Text('Abbrechen'),
+                                              ),
+                                              TextButton(
+                                                onPressed: () => Navigator.pop(ctx, true),
+                                                child: const Text('Ja'),
+                                              ),
+                                            ],
+                                          ),
+                                        );
+                                        if (confirm == true) {
+                                          await service.setMainProfile(uid, p.id);
+                                        }
+                                        break;
+                                      case _ProfileAction.openShop:
+                                        if (!context.mounted) return;
+                                        context.pushNamed(AppRouteNames.profileShop, extra: p);
+                                        break;
+                                      case _ProfileAction.delete:
+                                        await _deleteProfile(context, uid, p.id, isMain);
+                                        break;
+                                    }
+                                  },
+                                  itemBuilder: (ctx) => [
                                     if (!isMain)
-                                      IconButton(
-                                        icon: const Icon(Icons.star_border),
-                                        onPressed: () => service.setMainProfile(uid, p.id),
+                                      const PopupMenuItem(
+                                        value: _ProfileAction.setMain,
+                                        child: Text('Als Hauptprofil nutzen'),
                                       ),
-                                    IconButton(
-                                      icon: const Icon(Icons.delete),
-                                      onPressed: () => _deleteProfile(context, uid, p.id, isMain),
+                                    PopupMenuItem(
+                                      value: _ProfileAction.openShop,
+                                      child: Row(
+                                        children: const [
+                                          Icon(Icons.style, size: 18),
+                                          SizedBox(width: 8),
+                                          Text('Profil anpassen'),
+                                        ],
+                                      ),
+                                    ),
+                                    const PopupMenuItem(
+                                      value: _ProfileAction.delete,
+                                      child: Text('Löschen'),
                                     ),
                                   ],
                                 ),
@@ -136,6 +226,28 @@ class ProfileOverviewScreen extends StatelessWidget {
                       child: const Text('Neues Quiz starten'),
                     ),
                   ),
+                  if (mainProfile != null)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          OutlinedButton.icon(
+                            onPressed: () =>
+                                context.pushNamed(AppRouteNames.profileDetail, extra: mainProfile),
+                            icon: const Icon(Icons.insights_outlined),
+                            label: const Text('Ergebnisse anzeigen'),
+                          ),
+                          const SizedBox(height: 12),
+                          ElevatedButton.icon(
+                            onPressed: () =>
+                                context.pushNamed(AppRouteNames.profileShop, extra: mainProfile),
+                            icon: const Icon(Icons.style),
+                            label: const Text('Profil anpassen'),
+                          ),
+                        ],
+                      ),
+                    ),
                   if (showCommunityLinks)
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
@@ -170,3 +282,5 @@ class ProfileOverviewScreen extends StatelessWidget {
     );
   }
 }
+
+enum _ProfileAction { setMain, openShop, delete }

--- a/lib/features/profile/screens/reflex_profile_detail_screen.dart
+++ b/lib/features/profile/screens/reflex_profile_detail_screen.dart
@@ -1,41 +1,58 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../models/reflex_profile.dart';
 import '../../calendar/widgets/golden_day_banner.dart';
+import '../mappers/reflex_score_mapper.dart';
 
 class ReflexProfileDetailScreen extends StatelessWidget {
   final ReflexProfile profile;
   const ReflexProfileDetailScreen({super.key, required this.profile});
 
-  Color _colorForPercent(double p) {
-    if (p >= 0.75) return Colors.green;
-    if (p >= 0.5) return Colors.orange;
-    return Colors.red;
-  }
-
   @override
   Widget build(BuildContext context) {
+    final scores =
+        ReflexScoreMapper.fromStoredScores(profile.reflexScores);
     return Scaffold(
       appBar: AppBar(title: Text(profile.name)),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Visualisierung',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  ReflexRadarChartPlaceholder(scores: scores),
+                  const SizedBox(height: 12),
+                  ReflexBarChartPlaceholder(scores: scores),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
           const Text(
             'Reflexe',
             style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
-          ...profile.reflexScores.entries.map((e) {
-            final yes = e.value['yes'] as int? ?? 0;
-            final total = e.value['total'] as int? ?? 0;
-            final ratio = total == 0 ? 0.0 : yes / total;
-            final percent = (ratio * 100).round();
+          ...scores.map((vm) {
+            final ratio = vm.ratio;
+            final percent = vm.percentage;
             return ListTile(
-              title: Text(e.key),
+              title: Text(vm.reflexName),
               subtitle: Padding(
                 padding: const EdgeInsets.only(top: 4.0),
                 child: LinearProgressIndicator(
                   value: ratio,
-                  color: _colorForPercent(ratio),
+                  color: colorForRatio(ratio),
                   backgroundColor: Colors.grey.shade300,
                 ),
               ),
@@ -58,4 +75,128 @@ class ReflexProfileDetailScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+class ReflexRadarChartPlaceholder extends StatelessWidget {
+  const ReflexRadarChartPlaceholder({super.key, required this.scores});
+
+  final List<ReflexScoreViewModel> scores;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1,
+      child: CustomPaint(
+        painter: _RadarPainter(scores),
+        child: const Center(child: Text('Radar-Vorschau')), // placeholder label
+      ),
+    );
+  }
+}
+
+class ReflexBarChartPlaceholder extends StatelessWidget {
+  const ReflexBarChartPlaceholder({super.key, required this.scores});
+
+  final List<ReflexScoreViewModel> scores;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      children: scores.map((vm) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4.0),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 120,
+                child: Text(
+                  vm.reflexName,
+                  style: theme.textTheme.bodySmall,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: LinearProgressIndicator(
+                    value: vm.ratio,
+                    minHeight: 10,
+                    color: colorForRatio(vm.ratio),
+                    backgroundColor: Colors.grey.shade300,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                width: 40,
+                child: Text('${vm.percentage}%'),
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _RadarPainter extends CustomPainter {
+  _RadarPainter(this.scores);
+
+  final List<ReflexScoreViewModel> scores;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final count = scores.length;
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.shortestSide / 2.2;
+    final paintGrid = Paint()
+      ..color = Colors.grey.withOpacity(0.2)
+      ..style = PaintingStyle.stroke;
+    final paintFill = Paint()
+      ..color = Colors.blueAccent.withOpacity(0.2)
+      ..style = PaintingStyle.fill;
+    final paintStroke = Paint()
+      ..color = Colors.blueAccent
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+
+    for (var i = 1; i <= 3; i++) {
+      final r = radius * (i / 3);
+      canvas.drawCircle(center, r, paintGrid);
+    }
+
+    if (count == 0) {
+      return;
+    }
+
+    final path = Path();
+    for (var i = 0; i < count; i++) {
+      final angle = (2 * math.pi * i / count) - math.pi / 2;
+      final ratio = scores[i].ratio.clamp(0.0, 1.0);
+      final point = Offset(
+        center.dx + radius * ratio * math.cos(angle),
+        center.dy + radius * ratio * math.sin(angle),
+      );
+      if (i == 0) {
+        path.moveTo(point.dx, point.dy);
+      } else {
+        path.lineTo(point.dx, point.dy);
+      }
+    }
+    path.close();
+    canvas.drawPath(path, paintFill);
+    canvas.drawPath(path, paintStroke);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RadarPainter oldDelegate) {
+    return !listEquals(oldDelegate.scores, scores);
+  }
+}
+
+Color colorForRatio(double ratio) {
+  if (ratio >= 0.75) return Colors.green;
+  if (ratio >= 0.5) return Colors.orange;
+  return Colors.red;
 }

--- a/lib/features/profile/screens/shop_screen.dart
+++ b/lib/features/profile/screens/shop_screen.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/features/profile/models/cosmetic_item.dart';
+import 'package:free_base/features/profile/models/reflex_profile.dart';
+import 'package:free_base/features/profile/state/profile_shop_notifier.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+
+class ShopScreen extends StatefulWidget {
+  const ShopScreen({super.key, required this.profile});
+
+  final ReflexProfile profile;
+
+  @override
+  State<ShopScreen> createState() => _ShopScreenState();
+}
+
+class _ShopScreenState extends State<ShopScreen> {
+  String? _activeItemId;
+  int _xpSpent = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _activeItemId = widget.profile.avatarItemId;
+    _xpSpent = widget.profile.xpSpent;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final notifier = context.read<ProfileShopNotifier>();
+      await notifier.ensureCatalogLoaded();
+      await notifier.loadPurchases(widget.profile.id);
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant ShopScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.profile.id != widget.profile.id) {
+      _activeItemId = widget.profile.avatarItemId;
+      _xpSpent = widget.profile.xpSpent;
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        final notifier = context.read<ProfileShopNotifier>();
+        await notifier.loadPurchases(widget.profile.id);
+      });
+    }
+  }
+
+  Future<void> _onAction(CosmeticItem item) async {
+    final notifier = context.read<ProfileShopNotifier>();
+    final result = await notifier.purchaseOrApply(
+      profile: widget.profile,
+      item: item,
+    );
+    if (!mounted) return;
+    final message = result.message ?? 'Aktion ausgeführt';
+    if (result.outcome == ShopActionOutcome.purchased) {
+      setState(() {
+        _activeItemId = item.id;
+        _xpSpent += item.priceXp;
+      });
+    } else if (result.outcome == ShopActionOutcome.applied) {
+      setState(() {
+        _activeItemId = item.id;
+      });
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Widget _buildHeader(SessionNotifier sessionNotifier) {
+    final xpBalance = sessionNotifier.state.xpTotal;
+    final subtitle = 'Ausgegebene EXP: $_xpSpent';
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.profile.name,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text('Verfügbare EXP: $xpBalance'),
+            const SizedBox(height: 4),
+            Text(subtitle),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilter(ProfileShopNotifier notifier) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: Row(
+        children: [
+          const Text('Seltenheit:'),
+          const SizedBox(width: 12),
+          DropdownButton<CosmeticRarity?>(
+            value: notifier.filter,
+            items: const [
+              DropdownMenuItem(value: null, child: Text('Alle')),
+              DropdownMenuItem(
+                value: CosmeticRarity.common,
+                child: Text('Häufig'),
+              ),
+              DropdownMenuItem(
+                value: CosmeticRarity.rare,
+                child: Text('Selten'),
+              ),
+              DropdownMenuItem(
+                value: CosmeticRarity.epic,
+                child: Text('Episch'),
+              ),
+              DropdownMenuItem(
+                value: CosmeticRarity.legendary,
+                child: Text('Legendär'),
+              ),
+            ],
+            onChanged: notifier.setFilter,
+          ),
+          const Spacer(),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Aktualisieren',
+            onPressed: () async {
+              await notifier.refreshCatalog();
+              await notifier.loadPurchases(widget.profile.id);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemCard(
+    ProfileShopNotifier notifier,
+    CosmeticItem item,
+  ) {
+    final theme = Theme.of(context);
+    final owned = notifier.isOwned(widget.profile.id, item.id);
+    final isActive = _activeItemId == item.id;
+    final brightness = theme.colorScheme.brightness;
+    final accent = rarityColor(item.rarity, brightness: brightness);
+    final actionLabel = isActive
+        ? 'Aktiv'
+        : owned
+            ? 'Anwenden'
+            : 'Kaufen (${item.priceXp} XP)';
+    final isProcessing = notifier.isProcessing(item.id);
+
+    return Card(
+      elevation: isActive ? 4 : 1,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(
+          color: isActive ? accent : Colors.transparent,
+          width: 2,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircleAvatar(
+                    radius: 28,
+                    backgroundColor: accent.withOpacity(0.2),
+                    child: Icon(
+                      Icons.style,
+                      color: accent,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    item.name,
+                    style: theme.textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Seltenheit: ${cosmeticRarityToString(item.rarity)}',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: isActive || isProcessing ? null : () => _onAction(item),
+              child: isProcessing
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(actionLabel),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCatalog(
+    ProfileShopNotifier notifier,
+    SessionNotifier sessionNotifier,
+  ) {
+    if (notifier.hasError) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Der Shop konnte nicht geladen werden.'),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () async {
+                  await notifier.refreshCatalog();
+                  await notifier.loadPurchases(widget.profile.id);
+                },
+                child: const Text('Erneut versuchen'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final items = notifier.catalog;
+    if (notifier.isLoading && items.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (items.isEmpty) {
+      return const Center(child: Text('Keine kosmetischen Items verfügbar.'));
+    }
+
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: items.length,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 16,
+        crossAxisSpacing: 16,
+        childAspectRatio: 0.78,
+      ),
+      itemBuilder: (context, index) => _buildItemCard(notifier, items[index]),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer2<ProfileShopNotifier, SessionNotifier>(
+      builder: (context, notifier, sessionNotifier, _) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Kosmetik-Shop'),
+          ),
+          body: Column(
+            children: [
+              _buildHeader(sessionNotifier),
+              if (notifier.offline)
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Card(
+                    color: Colors.orangeAccent,
+                    child: Padding(
+                      padding: EdgeInsets.all(12.0),
+                      child: Text(
+                        'Offline-Modus: Es werden lokale Shop-Daten angezeigt.',
+                      ),
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 8),
+              _buildFilter(notifier),
+              const SizedBox(height: 8),
+              Expanded(
+                child: RefreshIndicator(
+                  onRefresh: () async {
+                    await notifier.refreshCatalog();
+                    await notifier.loadPurchases(widget.profile.id);
+                  },
+                  child: _buildCatalog(notifier, sessionNotifier),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/profile/services/profile_service.dart
+++ b/lib/features/profile/services/profile_service.dart
@@ -19,6 +19,28 @@ class ProfileService {
     return _db.collection('users').doc(userId).set(data, SetOptions(merge: true));
   }
 
+  Future<void> updateProfileAppearance(
+    String userId,
+    String profileId, {
+    String? avatarItemId,
+    int? xpSpentIncrement,
+  }) async {
+    final updates = <String, dynamic>{};
+    if (avatarItemId != null) {
+      updates['avatarItemId'] = avatarItemId;
+    }
+    if (xpSpentIncrement != null && xpSpentIncrement != 0) {
+      updates['xpSpent'] = FieldValue.increment(xpSpentIncrement);
+    }
+    if (updates.isEmpty) return;
+    await _db
+        .collection('users')
+        .doc(userId)
+        .collection('profiles')
+        .doc(profileId)
+        .set(updates, SetOptions(merge: true));
+  }
+
   /// Streamt alle Profile eines Nutzers sortiert nach Erstellungsdatum.
   Stream<List<ReflexProfile>> watchProfiles(String userId) {
     return _db

--- a/lib/features/profile/state/profile_shop_notifier.dart
+++ b/lib/features/profile/state/profile_shop_notifier.dart
@@ -1,0 +1,269 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import 'package:free_base/features/profile/models/cosmetic_item.dart';
+import 'package:free_base/features/profile/models/cosmetic_purchase.dart';
+import 'package:free_base/features/profile/models/reflex_profile.dart';
+import 'package:free_base/features/profile/services/profile_service.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+
+enum ShopActionOutcome { purchased, applied, insufficientXp, unauthorized, error }
+
+class ShopActionResult {
+  ShopActionResult(this.outcome, {this.message});
+
+  final ShopActionOutcome outcome;
+  final String? message;
+
+  bool get isSuccess =>
+      outcome == ShopActionOutcome.purchased || outcome == ShopActionOutcome.applied;
+}
+
+class ProfileShopNotifier extends ChangeNotifier {
+  ProfileShopNotifier({
+    required this.firestore,
+    required this.sessionNotifier,
+    required this.cacheBox,
+    ProfileService? profileService,
+  }) : _profileService = profileService ?? ProfileService();
+
+  final FirebaseFirestore firestore;
+  final SessionNotifier sessionNotifier;
+  final Box cacheBox;
+  final ProfileService _profileService;
+
+  final Map<String, List<CosmeticPurchase>> _purchasesByProfile = {};
+  final Set<String> _processingItems = {};
+
+  List<CosmeticItem> _catalog = [];
+  bool _isLoading = false;
+  bool _hasError = false;
+  bool _offline = false;
+  bool _catalogLoaded = false;
+  CosmeticRarity? _filter;
+
+  bool get isLoading => _isLoading;
+  bool get hasError => _hasError;
+  bool get offline => _offline;
+  CosmeticRarity? get filter => _filter;
+
+  List<CosmeticItem> get catalog {
+    if (_filter == null) return List.unmodifiable(_catalog);
+    return _catalog.where((item) => item.rarity == _filter).toList(growable: false);
+  }
+
+  bool isProcessing(String itemId) => _processingItems.contains(itemId);
+
+  List<CosmeticPurchase> purchasesFor(String profileId) =>
+      List.unmodifiable(_purchasesByProfile[profileId] ?? <CosmeticPurchase>[]);
+
+  bool isOwned(String profileId, String itemId) =>
+      _purchasesByProfile[profileId]?.any((p) => p.itemId == itemId) ?? false;
+
+  Future<void> ensureCatalogLoaded() async {
+    if (_catalogLoaded) return;
+    await loadCatalog();
+  }
+
+  Future<void> loadCatalog({bool forceRefresh = false}) async {
+    if (_isLoading) return;
+    if (_catalogLoaded && !forceRefresh) return;
+    _isLoading = true;
+    _hasError = false;
+    _offline = false;
+    notifyListeners();
+    try {
+      final snapshot = await firestore.collection('cosmetics_catalog').get();
+      _catalog = snapshot.docs
+          .map((doc) => CosmeticItem.fromMap(doc.data(), doc.id))
+          .toList()
+        ..sort((a, b) => a.priceXp.compareTo(b.priceXp));
+      _catalogLoaded = true;
+      await cacheBox.put(
+        'catalog',
+        _catalog.map((e) => e.toCache()).toList(),
+      );
+    } on FirebaseException catch (e) {
+      _offline = e.code == 'unavailable' || e.code == 'failed-precondition';
+      if (!await _loadCatalogFromCache()) {
+        _hasError = true;
+      }
+    } catch (_) {
+      if (!await _loadCatalogFromCache()) {
+        _hasError = true;
+      }
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> _loadCatalogFromCache() async {
+    final cached = cacheBox.get('catalog');
+    if (cached is List) {
+      _catalog = cached
+          .whereType<Map>()
+          .map((raw) {
+            final map = Map<String, dynamic>.from(raw as Map);
+            final id = map['id'] as String? ?? (map['name'] as String? ?? '').toLowerCase();
+            return CosmeticItem.fromMap(map, id);
+          })
+          .toList()
+        ..sort((a, b) => a.priceXp.compareTo(b.priceXp));
+      if (_catalog.isNotEmpty) {
+        _catalogLoaded = true;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Future<void> refreshCatalog() => loadCatalog(forceRefresh: true);
+
+  void setFilter(CosmeticRarity? rarity) {
+    _filter = rarity;
+    notifyListeners();
+  }
+
+  Future<void> loadPurchases(String profileId) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      _purchasesByProfile[profileId] = <CosmeticPurchase>[];
+      notifyListeners();
+      return;
+    }
+    try {
+      final snapshot = await firestore
+          .collection('users')
+          .doc(user.uid)
+          .collection('cosmetics')
+          .where('profileId', isEqualTo: profileId)
+          .orderBy('unlockedAt', descending: true)
+          .get();
+      _purchasesByProfile[profileId] = snapshot.docs
+          .map((doc) => CosmeticPurchase.fromMap(doc.data(), doc.id))
+          .toList();
+      notifyListeners();
+    } on FirebaseException catch (e) {
+      if (kDebugMode) {
+        debugPrint('Failed to load purchases: ${e.code}');
+      }
+    }
+  }
+
+  Future<ShopActionResult> purchaseOrApply({
+    required ReflexProfile profile,
+    required CosmeticItem item,
+  }) async {
+    if (isProcessing(item.id)) {
+      return ShopActionResult(
+        ShopActionOutcome.error,
+        message: 'Aktion läuft bereits.',
+      );
+    }
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      return ShopActionResult(ShopActionOutcome.unauthorized,
+          message: 'Bitte melde dich erneut an.');
+    }
+    if (profile.avatarItemId == item.id) {
+      return ShopActionResult(
+        ShopActionOutcome.applied,
+        message: 'Bereits aktiv.',
+      );
+    }
+    if (isOwned(profile.id, item.id)) {
+      return _applyItem(user.uid, profile, item);
+    }
+    if (sessionNotifier.state.xpTotal < item.priceXp) {
+      return ShopActionResult(
+        ShopActionOutcome.insufficientXp,
+        message: 'Nicht genügend EXP vorhanden.',
+      );
+    }
+    _processingItems.add(item.id);
+    notifyListeners();
+    try {
+      final docRef = firestore
+          .collection('users')
+          .doc(user.uid)
+          .collection('cosmetics')
+          .doc();
+      await firestore.runTransaction((transaction) async {
+        transaction.set(docRef, {
+          'profileId': profile.id,
+          'itemId': item.id,
+          'unlockedAt': FieldValue.serverTimestamp(),
+        });
+        transaction.set(
+          firestore
+              .collection('users')
+              .doc(user.uid)
+              .collection('profiles')
+              .doc(profile.id),
+          {
+            'avatarItemId': item.id,
+            'xpSpent': FieldValue.increment(item.priceXp),
+          },
+          SetOptions(merge: true),
+        );
+      });
+      sessionNotifier.spendXp(item.priceXp);
+      final purchase = CosmeticPurchase(
+        id: docRef.id,
+        profileId: profile.id,
+        itemId: item.id,
+        unlockedAt: DateTime.now(),
+      );
+      final current = List<CosmeticPurchase>.from(_purchasesByProfile[profile.id] ?? []);
+      current.insert(0, purchase);
+      _purchasesByProfile[profile.id] = current;
+      _processingItems.remove(item.id);
+      notifyListeners();
+      return ShopActionResult(ShopActionOutcome.purchased,
+          message: '${item.name} wurde freigeschaltet.');
+    } on FirebaseException catch (e) {
+      _processingItems.remove(item.id);
+      notifyListeners();
+      if (kDebugMode) {
+        debugPrint('Kauf fehlgeschlagen: ${e.code}');
+      }
+      if (e.code == 'unavailable') {
+        _offline = true;
+        notifyListeners();
+      }
+      return ShopActionResult(
+        ShopActionOutcome.error,
+        message: 'Kauf fehlgeschlagen. Bitte später erneut versuchen.',
+      );
+    }
+  }
+
+  Future<ShopActionResult> _applyItem(
+    String userId,
+    ReflexProfile profile,
+    CosmeticItem item,
+  ) async {
+    try {
+      await _profileService.updateProfileAppearance(
+        userId,
+        profile.id,
+        avatarItemId: item.id,
+      );
+      return ShopActionResult(
+        ShopActionOutcome.applied,
+        message: '${item.name} aktiviert.',
+      );
+    } on FirebaseException catch (e) {
+      if (kDebugMode) {
+        debugPrint('Aktivieren fehlgeschlagen: ${e.code}');
+      }
+      return ShopActionResult(
+        ShopActionOutcome.error,
+        message: 'Aktivierung nicht möglich.',
+      );
+    }
+  }
+}

--- a/lib/features/questionnaire/questionnaire_result_screen.dart
+++ b/lib/features/questionnaire/questionnaire_result_screen.dart
@@ -8,6 +8,7 @@ import 'package:free_base/services/feature_flags.dart';
 import 'package:free_base/services/telemetry/telemetry_service.dart';
 
 import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/profile/mappers/reflex_score_mapper.dart';
 
 import 'questionnaire_state.dart';
 
@@ -64,7 +65,8 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
     final telemetry = context.read<TelemetryService>();
     final featureFlags = context.read<FeatureFlags>();
     try {
-      await questionnaireState.saveResult(name: trimmed, context: context);
+      final profile =
+          await questionnaireState.saveResult(name: trimmed, context: context);
 
       sessionNotifier.markOnboardingComplete();
       final locale = Localizations.maybeLocaleOf(context)?.toLanguageTag() ?? 'de';
@@ -75,7 +77,11 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
       });
 
       if (!context.mounted) return;
-      context.goNamed(AppRouteNames.profile);
+      if (profile != null) {
+        context.goNamed(AppRouteNames.profileDetail, extra: profile);
+      } else {
+        context.goNamed(AppRouteNames.profile);
+      }
     } catch (e) {
       if (!context.mounted) return;
       final locale = Localizations.maybeLocaleOf(context);
@@ -96,6 +102,7 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
   @override
   Widget build(BuildContext context) {
     final summary = context.watch<QuestionnaireState>().calculateReflexSummary();
+    final viewModels = ReflexScoreMapper.fromSummary(summary);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Ergebnis')),
@@ -106,14 +113,11 @@ class _QuestionnaireResultScreenState extends State<QuestionnaireResultScreen> {
           children: [
             Expanded(
               child: ListView(
-                children: summary.entries.map((e) {
-                  final name = e.key;
-                  final yes = e.value[0];
-                  final total = e.value[1];
-                  final ratio = total == 0 ? 0.0 : yes / total;
-                  final percent = (ratio * 100).round();
+                children: viewModels.map((vm) {
+                  final ratio = vm.ratio;
+                  final percent = vm.percentage;
                   return ListTile(
-                    title: Text(name),
+                    title: Text(vm.reflexName),
                     subtitle: Padding(
                       padding: const EdgeInsets.only(top: 4.0),
                       child: LinearProgressIndicator(

--- a/lib/features/questionnaire/questionnaire_state.dart
+++ b/lib/features/questionnaire/questionnaire_state.dart
@@ -53,6 +53,8 @@ class QuestionnaireState extends ChangeNotifier {
   bool _isGerman = true;
   bool _initialized = false;
 
+  static const String questionnaireVersion = 'v1';
+
   QuestionnaireState(this._box);
 
   bool get isInitialized => _initialized;
@@ -186,7 +188,7 @@ class QuestionnaireState extends ChangeNotifier {
   }
 
   /// Speichert Ergebnis in Firestore und leert den lokalen Fortschritt.
-  Future<void> saveResult({
+  Future<ReflexProfile?> saveResult({
     String name = 'Reflexprofil',
     BuildContext? context,
   }) async {
@@ -198,7 +200,7 @@ class QuestionnaireState extends ChangeNotifier {
             : 'Please sign in to save the profile.';
         ErrorHandler.showErrorSnack(context, message);
       }
-      return;
+      return null;
     }
 
     try {
@@ -231,6 +233,8 @@ class QuestionnaireState extends ChangeNotifier {
         isMainProfile: isMainProfile,
         reflexScores: summary,
         answers: answers,
+        xpSpent: 0,
+        questionnaireVersion: questionnaireVersion,
       );
 
       await service.saveProfile(profile);
@@ -239,6 +243,7 @@ class QuestionnaireState extends ChangeNotifier {
       }
       await _box.clear();
       resetState();
+      return profile;
     } on FirebaseException catch (e, st) {
       if (kDebugMode) {
         debugPrint(
@@ -262,6 +267,7 @@ class QuestionnaireState extends ChangeNotifier {
         );
         ErrorHandler.showErrorSnack(context, message);
       }
+      return null;
     } catch (e, st) {
       if (kDebugMode) {
         debugPrint('Error saving questionnaire result: $e');
@@ -276,6 +282,7 @@ class QuestionnaireState extends ChangeNotifier {
             : 'Error saving. Please try again.';
         ErrorHandler.showErrorSnack(context, message);
       }
+      return null;
     }
   }
 }

--- a/lib/features/training/notifier/session_notifier.dart
+++ b/lib/features/training/notifier/session_notifier.dart
@@ -319,6 +319,17 @@ class SessionNotifier extends ChangeNotifier {
     }
   }
 
+  bool spendXp(int amount) {
+    if (amount <= 0) {
+      return true;
+    }
+    if (state.xpTotal < amount) {
+      return false;
+    }
+    state = state.copyWith(xpTotal: state.xpTotal - amount);
+    return true;
+  }
+
   bool _isSameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:free_base/features/calendar/services/calendar_service.dart';
 import 'package:free_base/features/calendar/services/golden_day_service.dart';
 import 'package:free_base/features/common/state/dashboard_view_model.dart';
 import 'package:free_base/features/questionnaire/questionnaire_screen.dart';
+import 'package:free_base/features/profile/state/profile_shop_notifier.dart';
 import 'package:free_base/services/app_intent_handler.dart';
 import 'package:free_base/services/app_route_guard.dart';
 import 'package:free_base/services/app_router.dart';
@@ -106,6 +107,9 @@ Future<void> main() async {
   await Hive.openBox<GamificationState>('gamification_state',
       encryptionCipher: HiveAesCipher(encryptionKey));
 
+  final cosmeticsBox = await Hive.openBox('cosmetics_catalog',
+      encryptionCipher: HiveAesCipher(encryptionKey));
+
   final sessionRepository = SessionRepository();
   final savedSession = await sessionRepository.load();
   final plannedFor = DateTime.now().add(const Duration(days: 1));
@@ -126,6 +130,7 @@ Future<void> main() async {
       sessionRepository: sessionRepository,
       initialSessionState: initialSessionState,
       consentBox: consentBox,
+      cosmeticsBox: cosmeticsBox,
     ),
   );
 }
@@ -134,6 +139,7 @@ class MyApp extends StatefulWidget {
   final SessionRepository sessionRepository;
   final SessionState initialSessionState;
   final Box<ConsentState> consentBox;
+  final Box cosmeticsBox;
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
       GlobalKey<ScaffoldMessengerState>();
 
@@ -142,6 +148,7 @@ class MyApp extends StatefulWidget {
     required this.sessionRepository,
     required this.initialSessionState,
     required this.consentBox,
+    required this.cosmeticsBox,
   });
 
   @override
@@ -257,6 +264,13 @@ class _MyAppState extends State<MyApp> {
             notifier.loadMonth(DateTime.now());
             return notifier;
           },
+        ),
+        ChangeNotifierProvider<ProfileShopNotifier>(
+          create: (ctx) => ProfileShopNotifier(
+            firestore: FirebaseFirestore.instance,
+            sessionNotifier: ctx.read<SessionNotifier>(),
+            cacheBox: widget.cosmeticsBox,
+          ),
         ),
         ChangeNotifierProxyProvider3<SessionNotifier, CalendarNotifier,
             ReminderService, DashboardViewModel>(

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -16,6 +16,7 @@ import 'package:free_base/features/onboarding/screens/role_selection_screen.dart
 import 'package:free_base/features/profile/models/reflex_profile.dart';
 import 'package:free_base/features/profile/screens/profile_overview_screen.dart';
 import 'package:free_base/features/profile/screens/reflex_profile_detail_screen.dart';
+import 'package:free_base/features/profile/screens/shop_screen.dart';
 import 'package:free_base/features/questionnaire/questionnaire_result_screen.dart';
 import 'package:free_base/features/questionnaire/questionnaire_screen.dart';
 import 'package:free_base/features/questionnaire/quiz_intro_screen.dart';
@@ -193,6 +194,19 @@ class AppRouter {
                       }
                       return const ErrorScreen(
                         message: 'Das Profil konnte nicht geladen werden.',
+                      );
+                    },
+                  ),
+                  GoRoute(
+                    path: 'shop',
+                    name: AppRouteNames.profileShop,
+                    builder: (context, state) {
+                      final profile = state.extra;
+                      if (profile is ReflexProfile) {
+                        return ShopScreen(profile: profile);
+                      }
+                      return const ErrorScreen(
+                        message: 'Der Shop konnte nicht geöffnet werden.',
                       );
                     },
                   ),

--- a/lib/services/app_routes.dart
+++ b/lib/services/app_routes.dart
@@ -8,6 +8,7 @@ class AppRoutePaths {
   static const training = '/training';
   static const calendar = '/calendar';
   static const profile = '/profile';
+  static const profileShop = '/profile/shop';
   static const settings = '/settings';
   static const questionnaireIntro = '/questionnaire';
   static const questionnaire = '/questionnaire/questions';
@@ -31,6 +32,7 @@ class AppRouteNames {
   static const calendar = 'calendar';
   static const profile = 'profile';
   static const profileDetail = 'profileDetail';
+  static const profileShop = 'profileShop';
   static const settings = 'settings';
   static const questionnaireIntro = 'questionnaireIntro';
   static const questionnaire = 'questionnaire';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ flutter:
 
   assets:
     - assets/images/
+    - assets/images/cosmetics/
     - assets/images/placeholder.png
     - assets/images/paw.png
     - assets/images/tick.png


### PR DESCRIPTION
## Summary
- add reflex score mapping utilities and radar/bar placeholders to profile views
- introduce cosmetic item models, profile shop notifier, and shop screen with XP purchases
- extend routing, providers, and onboarding flow to surface the cosmetic shop and avatar previews

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6904a2c99e88832d93a43714337a2744