### PR TITLE
Fix analyzer errors in Moro session controller

### DIFF
--- a/lib/features/training/models/session_state.dart
+++ b/lib/features/training/models/session_state.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 part 'session_state.freezed.dart';
 part 'session_state.g.dart';

--- a/lib/features/training/models/session_state.freezed.dart
+++ b/lib/features/training/models/session_state.freezed.dart
@@ -5,9 +5,6 @@
 
 part of 'session_state.dart';
 
-// ignore_for_file: unnecessary_import
-import 'package:collection/collection.dart';
-
 // **************************************************************************
 // FreezedGenerator
 // **************************************************************************

--- a/lib/features/training/moro/moro_session_controller.dart
+++ b/lib/features/training/moro/moro_session_controller.dart
@@ -114,7 +114,7 @@ class MoroSessionController extends ChangeNotifier {
     final startRepeat = _repeatIdx.clamp(1, exercise.repeats);
     final startPhase = _phaseIdx.clamp(1, exercise.phasesPerRepeat);
     final initialMs = _remaining.inMilliseconds > 0 ? _remaining.inMilliseconds : null;
-    final timer = exercise.type == MoroExerciseType.phased4x
+    final Stream<dynamic> timer = exercise.type == MoroExerciseType.phased4x
         ? PhasedMoroTimer(
             repeats: exercise.repeats,
             phasesPerRepeat: exercise.phasesPerRepeat,
@@ -135,19 +135,41 @@ class MoroSessionController extends ChangeNotifier {
           );
     final sw = Stopwatch()..start();
     _timerSubscription = timer.listen((event) {
-      if (!event.done) {
-        _repeatIdx = event.repeatIdx;
-        _phaseIdx = exercise.type == MoroExerciseType.phased4x
-            ? event.phaseIdx
-            : 1;
-        _remaining = event.remaining;
-        _sessionDuration = sw.elapsed;
-        _notifyResume();
+      if (exercise.type == MoroExerciseType.phased4x) {
+        final tick = event
+            as ({int repeatIdx, int phaseIdx, Duration remaining, bool done});
+        if (!tick.done) {
+          _repeatIdx = tick.repeatIdx;
+          _phaseIdx = tick.phaseIdx;
+          _remaining = tick.remaining;
+          _sessionDuration = sw.elapsed;
+          _notifyResume();
+        } else {
+          _sessionDuration = sw.elapsed;
+          _remaining = Duration.zero;
+          _notifyResume();
+          _handleActiveCompleted();
+        }
       } else {
-        _sessionDuration = sw.elapsed;
-        _remaining = Duration.zero;
-        _notifyResume();
-        _handleActiveCompleted();
+        final tick = event as ({
+          int repeatIdx,
+          Duration remaining,
+          bool done,
+          bool justStarted,
+          bool justEnded,
+        });
+        if (!tick.done) {
+          _repeatIdx = tick.repeatIdx;
+          _phaseIdx = 1;
+          _remaining = tick.remaining;
+          _sessionDuration = sw.elapsed;
+          _notifyResume();
+        } else {
+          _sessionDuration = sw.elapsed;
+          _remaining = Duration.zero;
+          _notifyResume();
+          _handleActiveCompleted();
+        }
       }
       notifyListeners();
     });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -338,7 +338,7 @@ packages:
     source: hosted
     version: "2.0.7"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dev_dependencies:
   freezed: ^2.3.2
   json_serializable: ^6.6.0
   intl_utils: ^2.8.9
+  fake_async: ^1.3.1
 
 flutter:
   generate: true


### PR DESCRIPTION
## Summary
- move the collection import into `session_state.dart` so the generated part stays valid
- update the Moro session controller to cast timer record payloads explicitly
- declare `fake_async` as a direct dev dependency to satisfy the new tests

## Testing
- ⚠️ `flutter analyze` *(fails: Flutter is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904ae8d292c832dac5f87dae14361d9