### PR TITLE
Support training intents for Moro flows

### DIFF
--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -94,6 +94,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 child: ElevatedButton(
                   onPressed: () => context.goNamed(
                     AppRouteNames.training,
+                    extra: TrainingIntent.start(),
                   ),
                   child: const Text('Training starten'),
                 ),

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/services/app_routes.dart';
+import 'package:free_base/services/training_intent.dart';
 
 import 'moro_exercise_screen.dart';
 import 'moro_models.dart';
@@ -13,7 +16,9 @@ import 'moro_speed_store.dart';
 import 'pre_check_screen.dart';
 
 class MoroTrainingScreen extends StatefulWidget {
-  const MoroTrainingScreen({super.key});
+  final TrainingIntent? intent;
+
+  const MoroTrainingScreen({super.key, this.intent});
   @override
   State<MoroTrainingScreen> createState() => _MoroTrainingScreenState();
 }
@@ -25,6 +30,15 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
   bool _autoplayEnabled = true;
   int _autoplayDelaySeconds = 3;
   bool _autoplayInitialized = false;
+  bool _intentHandled = false;
+
+  @override
+  void didUpdateWidget(covariant MoroTrainingScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.intent != oldWidget.intent) {
+      _intentHandled = false;
+    }
+  }
 
   @override
   void initState() {
@@ -180,6 +194,20 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
               }
               final progress = progressSnap.data!;
               final sessionNotifier = context.watch<SessionNotifier>();
+              final intent = widget.intent;
+              if (intent != null && !_intentHandled) {
+                _intentHandled = true;
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  _handleIntent(
+                    context,
+                    intent,
+                    items,
+                    progress,
+                    sessionNotifier,
+                  );
+                });
+              }
               final header = _buildStartCard(
                 context,
                 items,
@@ -362,6 +390,106 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
         }
       }
     }
+  }
+
+  void _handleIntent(
+    BuildContext context,
+    TrainingIntent intent,
+    List<MoroExercise> items,
+    MoroProgressData progress,
+    SessionNotifier notifier,
+  ) {
+    switch (intent.type) {
+      case TrainingIntentType.start:
+        unawaited(_startFromPrecheck(context, items, progress, notifier));
+        break;
+      case TrainingIntentType.resume:
+        unawaited(
+          _resumeFromIntent(
+            context,
+            items,
+            progress,
+            notifier,
+            intent.sessionId,
+          ),
+        );
+        break;
+    }
+  }
+
+  Future<void> _resumeFromIntent(
+    BuildContext context,
+    List<MoroExercise> items,
+    MoroProgressData progress,
+    SessionNotifier notifier,
+    String? sessionId,
+  ) async {
+    final resumeKey = _resolveResumeKey(sessionId, notifier, items);
+    if (resumeKey == null) {
+      await _startFromPrecheck(context, items, progress, notifier);
+      return;
+    }
+    MoroExercise? exercise;
+    for (final ex in items) {
+      if (ex.resumeKey == resumeKey) {
+        exercise = ex;
+        break;
+      }
+    }
+    exercise ??= _determineStartExercise(items, progress, notifier);
+    if (!notifier.state.moroResume.containsKey(exercise.resumeKey)) {
+      await _startFromPrecheck(context, items, progress, notifier);
+      return;
+    }
+    final offset = await _getOffset(exercise.index);
+    if (!mounted) return;
+    await _openExercise(context, exercise, offset, items.length, items);
+  }
+
+  String? _resolveResumeKey(
+    String? sessionId,
+    SessionNotifier notifier,
+    List<MoroExercise> items,
+  ) {
+    if (sessionId == null || sessionId.isEmpty) {
+      return null;
+    }
+    final resume = notifier.state.moroResume;
+    if (resume.containsKey(sessionId)) {
+      return sessionId;
+    }
+    final normalized = sessionId.toLowerCase();
+    for (final key in resume.keys) {
+      if (key.toLowerCase() == normalized) {
+        return key;
+      }
+    }
+    final colonIndex = normalized.lastIndexOf(':');
+    if (colonIndex != -1 && colonIndex < normalized.length - 1) {
+      final suffix = normalized.substring(colonIndex + 1);
+      if (resume.containsKey(suffix)) {
+        return suffix;
+      }
+      for (final key in resume.keys) {
+        if (key.toLowerCase() == suffix) {
+          return key;
+        }
+      }
+    }
+    final digitsMatch = RegExp(r'\d+').firstMatch(normalized);
+    if (digitsMatch != null) {
+      final idx = int.tryParse(digitsMatch.group(0)!);
+      if (idx != null) {
+        for (final ex in items) {
+          if (ex.index == idx) {
+            if (resume.containsKey(ex.resumeKey)) {
+              return ex.resumeKey;
+            }
+          }
+        }
+      }
+    }
+    return null;
   }
 }
 

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -28,6 +28,7 @@ import 'package:free_base/services/app_route_guard.dart';
 import 'package:free_base/services/app_shell.dart';
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/feature_flags.dart';
+import 'package:free_base/services/training_intent.dart';
 
 class AppRouter {
   AppRouter({
@@ -149,7 +150,12 @@ class AppRouter {
               GoRoute(
                 path: AppRoutePaths.training,
                 name: AppRouteNames.training,
-                builder: (context, state) => const MoroTrainingScreen(),
+                builder: (context, state) {
+                  final extra = state.extra;
+                  return MoroTrainingScreen(
+                    intent: extra is TrainingIntent ? extra : null,
+                  );
+                },
                 routes: [
                   GoRoute(
                     path: 'completed',

--- a/test/features/training/moro/moro_training_screen_test.dart
+++ b/test/features/training/moro/moro_training_screen_test.dart
@@ -1,0 +1,270 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hive/hive.dart';
+import 'package:provider/provider.dart';
+
+import 'package:free_base/features/calendar/models/calendar_event.dart';
+import 'package:free_base/features/calendar/services/calendar_service.dart';
+import 'package:free_base/features/calendar/services/golden_day_service.dart';
+import 'package:free_base/features/training/models/exercise_item.dart';
+import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/features/training/moro/moro_training_screen.dart';
+import 'package:free_base/features/training/moro/pre_check_screen.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+import 'package:free_base/features/training/services/exercise_repository.dart';
+import 'package:free_base/features/training/services/session_repository.dart';
+import 'package:free_base/features/training/services/sync_service.dart';
+import 'package:free_base/services/app_routes.dart';
+import 'package:free_base/services/training_intent.dart';
+
+class _TestSessionRepository extends SessionRepository {
+  SessionState? saved;
+
+  @override
+  Future<SessionState?> load() async => saved;
+
+  @override
+  Future<void> save(SessionState state) async {
+    saved = state;
+  }
+
+  @override
+  Future<void> clear() async {
+    saved = null;
+  }
+}
+
+class _TestSyncService implements SyncService {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> enqueue(SessionState state) async {}
+
+  @override
+  Stream<SyncStatusEvent> get statusStream => const Stream.empty();
+}
+
+class _TestCalendarService implements CalendarService {
+  @override
+  Future<void> addEvent(CalendarEvent event) async {}
+
+  @override
+  Future<void> removeEvent(String id) async {}
+
+  @override
+  Future<List<CalendarEvent>> loadEventsForMonth(DateTime month) async => const [];
+
+  @override
+  Future<void> saveTrainingDay(CalendarEvent event) async {}
+
+  @override
+  Future<DateTime?> loadUpcomingGoldenDay() async => null;
+}
+
+class _TestExerciseRepository extends ExerciseRepository {
+  final List<ExerciseItem> _items;
+
+  _TestExerciseRepository(this._items);
+
+  @override
+  List<ExerciseItem> getExercisesForPhase(String phaseId) => _items;
+}
+
+SessionNotifier _createNotifier() {
+  final items = List.generate(3, (index) {
+    final idx = index + 1;
+    return ExerciseItem(
+      id: 'moro-$idx',
+      name: 'Übung $idx',
+      imagePath: 'placeholder',
+      activeSeconds: 8,
+      restSeconds: 4,
+      repetitions: 1,
+    );
+  });
+  final repo = _TestSessionRepository();
+  final notifier = SessionNotifier(
+    repo,
+    _TestSyncService(),
+    _TestCalendarService(),
+    GoldenDayService(),
+    _TestExerciseRepository(items),
+    items,
+    SessionState(
+      phaseId: '0',
+      exerciseIndex: 0,
+      completedReps: 0,
+      remainingSeconds: items.first.activeSeconds,
+      isPaused: true,
+      startedAt: DateTime(2024, 1, 1),
+      plannedFor: DateTime(2024, 1, 1),
+      status: SessionStatus.planned,
+      moroResume: const {},
+    ),
+  );
+  return notifier;
+}
+
+class _AutoPopPrecheckScreen extends StatefulWidget {
+  const _AutoPopPrecheckScreen({required this.counter});
+
+  final ValueNotifier<int> counter;
+
+  @override
+  State<_AutoPopPrecheckScreen> createState() => _AutoPopPrecheckScreenState();
+}
+
+class _AutoPopPrecheckScreenState extends State<_AutoPopPrecheckScreen> {
+  @override
+  void initState() {
+    super.initState();
+    widget.counter.value++;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      GoRouter.of(context).pop(
+        const MoroPreCheckResult(
+          autoplayEnabled: true,
+          autoplayDelaySeconds: 3,
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('precheck')),
+    );
+  }
+}
+
+class _StubExerciseScreen extends StatelessWidget {
+  const _StubExerciseScreen({required this.exerciseId});
+
+  final String exerciseId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text('exercise-$exerciseId'),
+      ),
+    );
+  }
+}
+
+GoRouter _createRouter(ValueNotifier<int> counter) {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const SizedBox.shrink(),
+        routes: [
+          GoRoute(
+            path: 'training',
+            name: AppRouteNames.training,
+            builder: (context, state) => MoroTrainingScreen(
+              intent: state.extra is TrainingIntent ? state.extra as TrainingIntent : null,
+            ),
+            routes: [
+              GoRoute(
+                path: 'moro/precheck',
+                name: AppRouteNames.moroPrecheck,
+                builder: (context, state) => _AutoPopPrecheckScreen(counter: counter),
+              ),
+              GoRoute(
+                path: 'moro/:exerciseId',
+                name: AppRouteNames.moroExercise,
+                builder: (context, state) {
+                  final id = state.pathParameters['exerciseId']!;
+                  return _StubExerciseScreen(
+                    exerciseId: id,
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory hiveDir;
+
+  setUpAll(() async {
+    hiveDir = await Directory.systemTemp.createTemp('moro_training_test');
+    Hive.init(hiveDir.path);
+  });
+
+  tearDown(() async {
+    if (Hive.isBoxOpen('moro_progress')) {
+      await Hive.box('moro_progress').close();
+    }
+    try {
+      await Hive.deleteBoxFromDisk('moro_progress');
+    } catch (_) {}
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (hiveDir.existsSync()) {
+      await hiveDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('start intent triggers pre-check and opens first exercise', (tester) async {
+    final notifier = _createNotifier();
+    final counter = ValueNotifier<int>(0);
+    final router = _createRouter(counter);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SessionNotifier>.value(
+        value: notifier,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    router.goNamed(AppRouteNames.training, extra: TrainingIntent.start());
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(counter.value, greaterThanOrEqualTo(1));
+    expect(find.text('exercise-1'), findsOneWidget);
+  });
+
+  testWidgets('resume intent opens stored exercise without pre-check', (tester) async {
+    final notifier = _createNotifier();
+    notifier.saveResumePoint('moro_2', const {
+      'stage': 'active',
+      'repeatIdx': 1,
+      'phaseIdx': 1,
+      'remainingMs': 5000,
+    });
+    final counter = ValueNotifier<int>(0);
+    final router = _createRouter(counter);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SessionNotifier>.value(
+        value: notifier,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    router.goNamed(AppRouteNames.training, extra: TrainingIntent.resume('moro_2'));
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(counter.value, 0);
+    expect(find.text('exercise-2'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- forward GoRouter extras to the Moro training screen so training intents reach the feature
- auto-handle start and resume training intents inside MoroTrainingScreen, mapping resume IDs to saved progress
- ensure dashboard navigation passes a start intent and add widget tests that cover intent-driven start/resume flows

## Testing
- `flutter test test/features/training/moro/moro_training_screen_test.dart` *(fails: flutter executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904b94c55bc832da65d3b29a99050cb