### PR TITLE
Allow profile access before onboarding completion

### DIFF
--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -107,6 +107,8 @@ class AppRouteGuard {
         location == AppRoutePaths.trainingCompleted ||
         location == AppRoutePaths.dashboard ||
         location == AppRoutePaths.consent ||
+        location == AppRoutePaths.profile ||
+        location.startsWith('${AppRoutePaths.profile}/') ||
         location.startsWith(AppRoutePaths.calendar) ||
         location.startsWith(AppRoutePaths.questionnaireIntro) ||
         location.startsWith(AppRoutePaths.questionnaire)) {

--- a/test/services/app_route_guard_test.dart
+++ b/test/services/app_route_guard_test.dart
@@ -112,6 +112,33 @@ void main() {
       consentNotifier.dispose();
     });
 
+    test('allows profile routes when onboarding is not complete', () async {
+      final consentNotifier = await createNotifier(accepted: true);
+      final auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u2'), signedIn: true);
+      final guard = AppRouteGuard(
+        auth: auth,
+        consentNotifier: consentNotifier,
+        loadSessionState: () async => buildSessionState(onboardingComplete: false),
+        consentRequired: true,
+        userDataLoader: (_) async => const <String, dynamic>{
+          'role': 'member',
+          'firstSessionCompleted': false,
+        },
+      );
+
+      final profileRedirect = await guard.evaluateLocation(AppRoutePaths.profile);
+      expect(profileRedirect, isNull);
+
+      final profileShopRedirect =
+          await guard.evaluateLocation(AppRoutePaths.profileShop);
+      expect(profileShopRedirect, isNull);
+
+      final settingsRedirect = await guard.evaluateLocation(AppRoutePaths.settings);
+      expect(settingsRedirect, AppRoutePaths.training);
+
+      consentNotifier.dispose();
+    });
+
     test('allows dashboard when consent and onboarding are complete', () async {
       final consentNotifier = await createNotifier(accepted: true);
       final auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u3'), signedIn: true);


### PR DESCRIPTION
## Summary
- allow profile and nested routes to bypass onboarding completion requirements
- extend guard tests to cover profile access without onboarding and ensure other routes stay gated

## Testing
- flutter test test/services/app_route_guard_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904ce03c99c832d8c91f73e92e403ed