### PR TITLE
Refine dashboard week progress modeling

### DIFF
--- a/lib/features/calendar/notifier/calendar_notifier.dart
+++ b/lib/features/calendar/notifier/calendar_notifier.dart
@@ -52,22 +52,49 @@ class CalendarNotifier extends ChangeNotifier {
   /// Lädt alle Events des Monats [month] und behält bereits
   /// geladene Monate im Speicher, damit Marker beim Scrollen
   /// nicht verloren gehen.
-  Future<void> loadMonth(DateTime month) async {
+  Future<void> loadMonth(
+    DateTime month, {
+    DateTime? ensureWeekForDay,
+  }) async {
     _focusedDay = month;
-    final events = await _service.loadEventsForMonth(month);
 
-    // Entferne nur die Einträge des geladenen Monats, damit
-    // andere Monate weiterhin angezeigt werden können.
-    final keysToRemove = _eventsByDay.keys
-        .where((d) => d.year == month.year && d.month == month.month)
-        .toList();
-    for (final key in keysToRemove) {
-      _eventsByDay.remove(key);
+    final monthsToLoad = <DateTime>{
+      DateTime(month.year, month.month),
+    };
+
+    final weekAnchor = ensureWeekForDay ?? _selectedDay;
+    final weekStart = weekAnchor.subtract(Duration(days: weekAnchor.weekday - DateTime.monday));
+    final weekEnd = weekStart.add(const Duration(days: 6));
+
+    void addMonth(DateTime date) {
+      monthsToLoad.add(DateTime(date.year, date.month));
     }
 
-    for (var ev in events) {
-      final key = DateTime(ev.date.year, ev.date.month, ev.date.day);
-      _eventsByDay.putIfAbsent(key, () => []).add(ev);
+    addMonth(weekStart);
+    addMonth(weekEnd);
+
+    DateTime cursor = DateTime(weekStart.year, weekStart.month);
+    final lastMonth = DateTime(weekEnd.year, weekEnd.month);
+    while (cursor.year < lastMonth.year ||
+        (cursor.year == lastMonth.year && cursor.month < lastMonth.month)) {
+      cursor = _nextMonth(cursor);
+      monthsToLoad.add(cursor);
+    }
+
+    for (final monthKey in monthsToLoad) {
+      final events = await _service.loadEventsForMonth(monthKey);
+
+      final keysToRemove = _eventsByDay.keys
+          .where((d) => d.year == monthKey.year && d.month == monthKey.month)
+          .toList();
+      for (final key in keysToRemove) {
+        _eventsByDay.remove(key);
+      }
+
+      for (var ev in events) {
+        final key = DateTime(ev.date.year, ev.date.month, ev.date.day);
+        _eventsByDay.putIfAbsent(key, () => []).add(ev);
+      }
     }
     notifyListeners();
   }
@@ -76,7 +103,7 @@ class CalendarNotifier extends ChangeNotifier {
   void selectDay(DateTime day) {
     _selectedDay = day;
     if (day.year != _focusedDay.year || day.month != _focusedDay.month) {
-      loadMonth(day);
+      loadMonth(day, ensureWeekForDay: day);
     } else {
       notifyListeners();
     }
@@ -143,6 +170,30 @@ class CalendarNotifier extends ChangeNotifier {
     }
 
     await toggleCompleted(list.first);
+  }
+
+  /// Returns true when a day has been completed but no reflection has been saved yet.
+  bool requiresReflection(DateTime day) {
+    final events = eventsForDay(day);
+    if (events.isEmpty) {
+      return false;
+    }
+    final today = DateTime.now();
+    final normalizedDay = DateTime(day.year, day.month, day.day);
+    final normalizedToday = DateTime(today.year, today.month, today.day);
+    if (!normalizedDay.isBefore(normalizedToday)) {
+      return false;
+    }
+    final hasCompletion = events.any((e) => e.isCompleted);
+    final hasReflection = events.any((e) => e.notes.trim().isNotEmpty);
+    return hasCompletion && !hasReflection;
+  }
+
+  DateTime _nextMonth(DateTime date) {
+    if (date.month == 12) {
+      return DateTime(date.year + 1, 1);
+    }
+    return DateTime(date.year, date.month + 1);
   }
 
 }

--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -70,7 +70,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
           SessionStatusBanner.fromSession(state),
           const SizedBox(height: 16),
           DashboardCalendarCard(
-            summary: dashboard.currentWeekSummary,
+            weekProgress: dashboard.currentWeekProgress,
             onOpenCalendar: () => context.goNamed(AppRouteNames.calendar),
             onReminderTap: () => _handleReminderTap(context, dashboard),
             reminderTime: dashboard.scheduledReminder,

--- a/lib/features/common/state/dashboard_view_model.dart
+++ b/lib/features/common/state/dashboard_view_model.dart
@@ -1,30 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:free_base/features/calendar/notifier/calendar_notifier.dart';
+import 'package:free_base/features/progress/models/week_progress.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/services/reminder/reminder_service.dart';
-
-class CalendarWeekSummary {
-  final DateTime weekStart;
-  final int plannedDays;
-  final int completedDays;
-  final bool hasGoldenDay;
-
-  const CalendarWeekSummary({
-    required this.weekStart,
-    required this.plannedDays,
-    required this.completedDays,
-    required this.hasGoldenDay,
-  });
-
-  double get completionRate {
-    if (plannedDays == 0) {
-      return 0;
-    }
-    return completedDays / plannedDays;
-  }
-
-  DateTime get weekEnd => weekStart.add(const Duration(days: 6));
-}
 
 class DashboardViewModel extends ChangeNotifier {
   static const int _xpPerLevel = 100;
@@ -91,7 +69,13 @@ class DashboardViewModel extends ChangeNotifier {
 
   double get levelProgress => xpIntoLevel / _xpPerLevel;
 
-  CalendarWeekSummary get currentWeekSummary => _calculateCurrentWeekSummary();
+  CoreWeekProgress get currentWeekProgress => _calculateCurrentWeekProgress();
+
+  WeekProgressStats get currentWeekStats => currentWeekProgress.stats;
+
+  double get progressRatio => currentWeekProgress.progressRatio;
+
+  int? get todayIndex => currentWeekProgress.todayIndex;
 
   TimeOfDay? get scheduledReminder => _reminderService.scheduledTime;
 
@@ -105,33 +89,29 @@ class DashboardViewModel extends ChangeNotifier {
     await _reminderService.cancelDailyReminder();
   }
 
-  CalendarWeekSummary _calculateCurrentWeekSummary() {
+  CoreWeekProgress _calculateCurrentWeekProgress() {
     final now = DateTime.now();
     final start = now.subtract(Duration(days: now.weekday - DateTime.monday));
-    var plannedDays = 0;
-    var completedDays = 0;
-    var hasGoldenDay = false;
+    final days = <DayProgressNode>[];
 
     for (var i = 0; i < 7; i++) {
       final day = DateTime(start.year, start.month, start.day + i);
       final events = _calendarNotifier.eventsForDay(day);
-      if (events.isEmpty) {
-        continue;
-      }
-      plannedDays += 1;
-      if (events.any((e) => e.isCompleted)) {
-        completedDays += 1;
-      }
-      if (!hasGoldenDay && events.any((e) => e.isGoldenDay)) {
-        hasGoldenDay = true;
-      }
+      days.add(
+        DayProgressNode(
+          date: day,
+          isPlanned: events.isNotEmpty,
+          isCompleted: events.any((e) => e.isCompleted),
+          isGoldenDay: events.any((e) => e.isGoldenDay),
+          hasReflection: events.any((e) => e.notes.trim().isNotEmpty),
+        ),
+      );
     }
 
-    return CalendarWeekSummary(
-      weekStart: DateTime(start.year, start.month, start.day),
-      plannedDays: plannedDays,
-      completedDays: completedDays,
-      hasGoldenDay: hasGoldenDay,
+    return CoreWeekProgress(
+      windowStart: DateTime(start.year, start.month, start.day),
+      windowEnd: DateTime(start.year, start.month, start.day + 6),
+      days: days,
     );
   }
 

--- a/lib/features/common/widgets/dashboard_calendar_card.dart
+++ b/lib/features/common/widgets/dashboard_calendar_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:free_base/features/common/state/dashboard_view_model.dart';
+import 'package:free_base/features/progress/models/week_progress.dart';
 
 class DashboardCalendarCard extends StatelessWidget {
-  final CalendarWeekSummary summary;
+  final CoreWeekProgress weekProgress;
   final VoidCallback onOpenCalendar;
   final VoidCallback onReminderTap;
   final TimeOfDay? reminderTime;
@@ -10,7 +10,7 @@ class DashboardCalendarCard extends StatelessWidget {
 
   const DashboardCalendarCard({
     super.key,
-    required this.summary,
+    required this.weekProgress,
     required this.onOpenCalendar,
     required this.onReminderTap,
     required this.reminderTime,
@@ -21,8 +21,9 @@ class DashboardCalendarCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final secondaryStyle = theme.textTheme.bodyMedium;
-    final plannedDays = summary.plannedDays;
-    final completedDays = summary.completedDays;
+    final stats = weekProgress.stats;
+    final plannedDays = stats.plannedDays;
+    final completedDays = stats.completedDays;
     final completionText = plannedDays == 0
         ? 'Noch keine Trainings geplant'
         : '$completedDays von $plannedDays Tagen abgeschlossen';
@@ -30,6 +31,10 @@ class DashboardCalendarCard extends StatelessWidget {
     final reminderLabel = reminderActive
         ? 'Reminder: ${reminderTime?.format(context) ?? ''}'
         : 'Erinnerung setzen';
+
+    final reflectionText = stats.hasPendingReflections
+        ? 'Reflexion ausstehend für ${stats.pendingReflections} Tag(e).'
+        : null;
 
     return Card(
       elevation: 2,
@@ -46,7 +51,7 @@ class DashboardCalendarCard extends StatelessWidget {
                     style: theme.textTheme.titleMedium,
                   ),
                 ),
-                if (summary.hasGoldenDay)
+                if (weekProgress.hasGoldenDay)
                   Chip(
                     avatar: const Icon(Icons.bug_report_outlined),
                     label: const Text('Golden Day in Sicht'),
@@ -55,13 +60,17 @@ class DashboardCalendarCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             LinearProgressIndicator(
-              value: summary.completionRate.clamp(0, 1),
+              value: weekProgress.progressRatio.clamp(0, 1),
             ),
             const SizedBox(height: 8),
             Text(completionText, style: secondaryStyle),
+            if (reflectionText != null) ...[
+              const SizedBox(height: 4),
+              Text(reflectionText, style: secondaryStyle),
+            ],
             const SizedBox(height: 8),
             Text(
-              'Zeitraum: ${_formatDate(summary.weekStart)} - ${_formatDate(summary.weekEnd)}',
+              'Zeitraum: ${_formatDate(weekProgress.windowStart)} - ${_formatDate(weekProgress.windowEnd)}',
               style: secondaryStyle,
             ),
             const SizedBox(height: 16),

--- a/lib/features/progress/models/week_progress.dart
+++ b/lib/features/progress/models/week_progress.dart
@@ -1,0 +1,129 @@
+import 'dart:collection';
+
+/// Represents a single day in a progress overview.
+///
+/// The node stores meta information whether the day had
+/// training planned, if it was completed and if it contained
+/// special markers such as a golden day. Reflection data is
+/// derived from the stored notes on the corresponding
+/// calendar event.
+class DayProgressNode {
+  DayProgressNode({
+    required DateTime date,
+    required this.isPlanned,
+    required this.isCompleted,
+    this.isGoldenDay = false,
+    this.hasReflection = false,
+  }) : date = DateTime(date.year, date.month, date.day);
+
+  /// Normalised date (time set to midnight).
+  final DateTime date;
+
+  /// True when the day contains at least one scheduled training.
+  final bool isPlanned;
+
+  /// True when one of the scheduled trainings was marked as completed.
+  final bool isCompleted;
+
+  /// Whether the day is flagged as a "golden day".
+  final bool isGoldenDay;
+
+  /// Indicates whether a reflection or day summary exists for that day.
+  final bool hasReflection;
+
+  DateTime get _today {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day);
+  }
+
+  /// True when the node represents the current day.
+  bool get isToday => date == _today;
+
+  /// True when the node is in the future.
+  bool get isFuture => date.isAfter(_today);
+
+  /// True when the node is in the past.
+  bool get isPast => date.isBefore(_today);
+
+  /// Helper indicating if a reflection prompt should be shown.
+  bool get requiresReflection => isCompleted && !hasReflection && isPast;
+}
+
+/// Core representation of a seven day progress window.
+class CoreWeekProgress {
+  CoreWeekProgress({
+    required DateTime windowStart,
+    required DateTime windowEnd,
+    required Iterable<DayProgressNode> days,
+  })  : windowStart = DateTime(windowStart.year, windowStart.month, windowStart.day),
+        windowEnd = DateTime(windowEnd.year, windowEnd.month, windowEnd.day),
+        _days = List<DayProgressNode>.unmodifiable(
+          (List<DayProgressNode>.from(days)..sort((a, b) => a.date.compareTo(b.date))),
+        );
+
+  /// Inclusive window start of the tracked seven day period.
+  final DateTime windowStart;
+
+  /// Inclusive window end of the tracked seven day period.
+  final DateTime windowEnd;
+
+  final List<DayProgressNode> _days;
+
+  /// Unmodifiable view of the stored days in chronological order.
+  UnmodifiableListView<DayProgressNode> get days => UnmodifiableListView(_days);
+
+  /// Number of days that contain a planned training session.
+  int get plannedDaysCount => _days.where((d) => d.isPlanned).length;
+
+  /// Number of days with completed training sessions.
+  int get completedDaysCount => _days.where((d) => d.isCompleted).length;
+
+  /// Completion ratio for the tracked window.
+  double get progressRatio {
+    if (plannedDaysCount == 0) {
+      return 0;
+    }
+    return completedDaysCount / plannedDaysCount;
+  }
+
+  /// Returns the index of the current day inside the window or `null` if not present.
+  int? get todayIndex {
+    final today = DateTime.now();
+    final normalized = DateTime(today.year, today.month, today.day);
+    for (var i = 0; i < _days.length; i++) {
+      if (_days[i].date == normalized) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  /// Returns true if any day in the week is flagged as golden day.
+  bool get hasGoldenDay => _days.any((d) => d.isGoldenDay);
+
+  /// Convenience getter exposing derived statistics.
+  WeekProgressStats get stats => WeekProgressStats(
+        plannedDays: plannedDaysCount,
+        completedDays: completedDaysCount,
+        pendingReflections:
+            _days.where((node) => node.requiresReflection).length,
+      );
+}
+
+/// Aggregated statistics for a [`CoreWeekProgress`].
+class WeekProgressStats {
+  const WeekProgressStats({
+    required this.plannedDays,
+    required this.completedDays,
+    required this.pendingReflections,
+  });
+
+  final int plannedDays;
+  final int completedDays;
+  final int pendingReflections;
+
+  bool get hasPlannedDays => plannedDays > 0;
+
+  /// Whether there is at least one day that should prompt a reflection.
+  bool get hasPendingReflections => pendingReflections > 0;
+}


### PR DESCRIPTION
## Summary
- add week progress models providing day nodes, stats helpers, and reflection metadata
- refactor the dashboard view model and calendar card to consume the new progress models and expose selectors
- extend calendar month loading to cover cross-boundary week windows and surface reflection utilities

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6904e22fa7cc832db40e95ac5818b4d2