### PR TITLE
Refactor dashboard progress section

### DIFF
--- a/lib/features/common/dashboard_screen.dart
+++ b/lib/features/common/dashboard_screen.dart
@@ -6,8 +6,9 @@ import 'package:provider/provider.dart';
 
 import 'package:free_base/features/common/dashboard_route_args.dart';
 import 'package:free_base/features/common/state/dashboard_view_model.dart';
-import 'package:free_base/features/common/widgets/dashboard_calendar_card.dart';
 import 'package:free_base/features/common/widgets/dashboard_header.dart';
+import 'package:free_base/features/progress/models/week_progress.dart';
+import 'package:free_base/features/progress/widgets/core_progress_section.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/features/training/widgets/session_status_banner.dart';
 import 'package:free_base/services/app_routes.dart';
@@ -50,71 +51,107 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Widget build(BuildContext context) {
     final sessionNotifier = context.watch<SessionNotifier>();
     final state = sessionNotifier.state;
-    final dashboard = context.watch<DashboardViewModel>();
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
       body: ListView(
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+        physics: const BouncingScrollPhysics(
+          parent: AlwaysScrollableScrollPhysics(),
+        ),
         children: [
-          DashboardHeader(
-            level: dashboard.currentLevel,
-            levelProgress: dashboard.levelProgress,
-            xpTotal: dashboard.xpTotal,
-            xpToNextLevel: dashboard.xpToNextLevel,
-            streakCount: dashboard.streakCount,
-            freezeAvailable: dashboard.freezeAvailable,
-            dailyXp: dashboard.dailyXp,
-            freezeUntil: dashboard.streakFrozenUntil,
+          Selector<DashboardViewModel, _DashboardHeaderData>(
+            selector: (_, vm) => _DashboardHeaderData(
+              level: vm.currentLevel,
+              levelProgress: vm.levelProgress,
+              xpTotal: vm.xpTotal,
+              xpToNextLevel: vm.xpToNextLevel,
+              streakCount: vm.streakCount,
+              freezeAvailable: vm.freezeAvailable,
+              dailyXp: vm.dailyXp,
+              freezeUntil: vm.streakFrozenUntil,
+            ),
+            builder: (context, data, _) {
+              return DashboardHeader(
+                level: data.level,
+                levelProgress: data.levelProgress,
+                xpTotal: data.xpTotal,
+                xpToNextLevel: data.xpToNextLevel,
+                streakCount: data.streakCount,
+                freezeAvailable: data.freezeAvailable,
+                dailyXp: data.dailyXp,
+                freezeUntil: data.freezeUntil,
+              );
+            },
           ),
           const SizedBox(height: 16),
           SessionStatusBanner.fromSession(state),
-          const SizedBox(height: 16),
-          DashboardCalendarCard(
-            weekProgress: dashboard.currentWeekProgress,
-            onOpenCalendar: () => context.goNamed(AppRouteNames.calendar),
-            onReminderTap: () => _handleReminderTap(context, dashboard),
-            reminderTime: dashboard.scheduledReminder,
-            reminderActive: dashboard.hasScheduledReminder,
+          const SizedBox(height: 24),
+          Selector<DashboardViewModel, CoreWeekProgress>(
+            selector: (_, vm) => vm.currentWeekProgress,
+            builder: (context, progress, _) {
+              final stats = progress.stats;
+              return CoreProgressSection(
+                progress: progress,
+                onStartTraining: () => _startTraining(context),
+                onStartNextWeek: () => _startNextWeek(context),
+                onOpenReflection: stats.hasPendingReflections
+                    ? () => _openReflection(context)
+                    : null,
+              );
+            },
           ),
           const SizedBox(height: 24),
+          Selector<DashboardViewModel, _ReminderStatus>(
+            selector: (_, vm) => _ReminderStatus(
+              hasScheduledReminder: vm.hasScheduledReminder,
+              scheduledReminder: vm.scheduledReminder,
+            ),
+            builder: (context, reminder, _) {
+              return _ReminderCard(
+                active: reminder.hasScheduledReminder,
+                time: reminder.scheduledReminder,
+                onTap: () => _handleReminderTap(
+                  context,
+                  context.read<DashboardViewModel>(),
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: 32),
           Text(
             'Bleib dran: Jede Einheit bringt dich deinem Ziel ein Stück näher.',
             style: Theme.of(context).textTheme.bodyLarge,
           ),
         ],
       ),
-      bottomNavigationBar: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: () => context.goNamed(
-                    AppRouteNames.training,
-                    extra: TrainingIntent.start(),
-                  ),
-                  child: const Text('Training starten'),
-                ),
-              ),
-              const SizedBox(height: 12),
-              SizedBox(
-                width: double.infinity,
-                child: OutlinedButton(
-                  onPressed: () => context.goNamed(
-                    AppRouteNames.calendar,
-                    queryParameters: const {'setReminder': 'true'},
-                  ),
-                  child: const Text('Nächstes Training planen'),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
     );
+  }
+
+  void _startTraining(BuildContext context) {
+    context.goNamed(
+      AppRouteNames.training,
+      extra: TrainingIntent.start(),
+    );
+  }
+
+  Future<void> _startNextWeek(BuildContext context) async {
+    final dashboard = context.read<DashboardViewModel>();
+    await dashboard.startNextWeek();
+    if (!mounted) return;
+    context.goNamed(AppRouteNames.calendar);
+  }
+
+  Future<void> _openReflection(BuildContext context) async {
+    final dashboard = context.read<DashboardViewModel>();
+    final opened = await dashboard.openReflection();
+    if (!mounted) return;
+    if (opened) {
+      context.goNamed(AppRouteNames.calendar);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Keine Reflexionen offen.')),
+      );
+    }
   }
 
   Future<void> _handleReminderTap(
@@ -183,4 +220,111 @@ class _DashboardScreenState extends State<DashboardScreen> {
       );
     }
   }
+}
+
+class _ReminderCard extends StatelessWidget {
+  const _ReminderCard({
+    required this.active,
+    required this.time,
+    required this.onTap,
+  });
+
+  final bool active;
+  final TimeOfDay? time;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final icon = active ? Icons.alarm_on : Icons.alarm_add;
+    final title = active ? 'Reminder aktiv' : 'Reminder setzen';
+    final timeLabel = time?.format(context);
+    final subtitle = active
+        ? (timeLabel != null && timeLabel.isNotEmpty
+            ? 'Tägliche Erinnerung um $timeLabel'
+            : 'Tägliche Erinnerung aktiv')
+        : 'Plane eine tägliche Trainings-Erinnerung.';
+
+    return Card(
+      child: ListTile(
+        leading: Icon(icon, color: theme.colorScheme.primary),
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+class _DashboardHeaderData {
+  const _DashboardHeaderData({
+    required this.level,
+    required this.levelProgress,
+    required this.xpTotal,
+    required this.xpToNextLevel,
+    required this.streakCount,
+    required this.freezeAvailable,
+    required this.dailyXp,
+    required this.freezeUntil,
+  });
+
+  final int level;
+  final double levelProgress;
+  final int xpTotal;
+  final int xpToNextLevel;
+  final int streakCount;
+  final bool freezeAvailable;
+  final int dailyXp;
+  final DateTime? freezeUntil;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _DashboardHeaderData &&
+        other.level == level &&
+        other.levelProgress == levelProgress &&
+        other.xpTotal == xpTotal &&
+        other.xpToNextLevel == xpToNextLevel &&
+        other.streakCount == streakCount &&
+        other.freezeAvailable == freezeAvailable &&
+        other.dailyXp == dailyXp &&
+        other.freezeUntil == freezeUntil;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        level,
+        levelProgress,
+        xpTotal,
+        xpToNextLevel,
+        streakCount,
+        freezeAvailable,
+        dailyXp,
+        freezeUntil,
+      );
+}
+
+class _ReminderStatus {
+  const _ReminderStatus({
+    required this.hasScheduledReminder,
+    required this.scheduledReminder,
+  });
+
+  final bool hasScheduledReminder;
+  final TimeOfDay? scheduledReminder;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _ReminderStatus &&
+        other.hasScheduledReminder == hasScheduledReminder &&
+        other.scheduledReminder == scheduledReminder;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        hasScheduledReminder,
+        scheduledReminder,
+      );
 }

--- a/lib/features/common/state/dashboard_view_model.dart
+++ b/lib/features/common/state/dashboard_view_model.dart
@@ -89,6 +89,42 @@ class DashboardViewModel extends ChangeNotifier {
     await _reminderService.cancelDailyReminder();
   }
 
+  Future<bool> startNextWeek() async {
+    final nextWeekStart =
+        currentWeekProgress.windowEnd.add(const Duration(days: 1));
+    final normalized = DateTime(
+      nextWeekStart.year,
+      nextWeekStart.month,
+      nextWeekStart.day,
+    );
+    await _calendarNotifier.loadMonth(
+      normalized,
+      ensureWeekForDay: normalized,
+    );
+    _calendarNotifier.selectDay(normalized);
+    return true;
+  }
+
+  Future<bool> openReflection() async {
+    final progress = currentWeekProgress;
+    DayProgressNode? pending;
+    for (final node in progress.days) {
+      if (node.requiresReflection) {
+        pending = node;
+        break;
+      }
+    }
+    if (pending == null) {
+      return false;
+    }
+    await _calendarNotifier.loadMonth(
+      pending.date,
+      ensureWeekForDay: pending.date,
+    );
+    _calendarNotifier.selectDay(pending.date);
+    return true;
+  }
+
   CoreWeekProgress _calculateCurrentWeekProgress() {
     final now = DateTime.now();
     final start = now.subtract(Duration(days: now.weekday - DateTime.monday));


### PR DESCRIPTION
## Summary
- replace the dashboard calendar card with the shared core progress section and hook up training, next-week, and reflection callbacks
- add a reminder card, adjust dashboard scrolling, and wire selectors for the header and progress content
- extend the dashboard view model with helpers to preselect next-week planning and pending reflections in the calendar

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6904eda91fe4832db1391a27a8e61aff