### PR TITLE
Remove stray text artifacts from core progress section

### DIFF
--- a/lib/features/progress/widgets/core_progress_section.dart
+++ b/lib/features/progress/widgets/core_progress_section.dart
@@ -94,11 +94,9 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
     super.initState();
     _windowKey = _windowKeyFor(widget.progress);
     _audioPlayer = AudioPlayer(playerId: 'progress_feedback_${hashCode}');
- codex/add-telemetry-service-hooks-to-core_progress_section
     unawaited(_audioPlayer.setReleaseMode(ReleaseMode.stop));
 
     unawaited(_configureAudioPlayer());
- gpt
   }
 
   @override
@@ -173,8 +171,6 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
     );
   }
 
- codex/add-telemetry-service-hooks-to-core_progress_section
-
   Future<void> _configureAudioPlayer() async {
     await _audioPlayer.setReleaseMode(ReleaseMode.stop);
     if (!kIsWeb) {
@@ -195,8 +191,6 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
       );
     }
   }
-
- gpt
   ProgressFeedbackHooks _mergedFeedbackHooks() {
     final external = widget.feedbackHooks;
 


### PR DESCRIPTION
## Summary
- remove leftover prompt fragments from `CoreProgressSection`
- ensure audio player initialization and helper methods compile without extraneous tokens

## Testing
- (not run)

------
https://chatgpt.com/codex/tasks/task_e_6904fa7885b4832dbe0b010dbfd133ed