### PR TITLE
Fix audioplayers context setup in progress section

### DIFF
--- a/lib/features/progress/widgets/core_progress_section.dart
+++ b/lib/features/progress/widgets/core_progress_section.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 
 import 'package:audioplayers/audioplayers.dart';
-
-
+import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
 import 'package:flutter/foundation.dart';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -94,11 +92,9 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
     super.initState();
     _windowKey = _windowKeyFor(widget.progress);
     _audioPlayer = AudioPlayer(playerId: 'progress_feedback_${hashCode}');
- codex/add-telemetry-service-hooks-to-core_progress_section
     unawaited(_audioPlayer.setReleaseMode(ReleaseMode.stop));
 
     unawaited(_configureAudioPlayer());
- gpt
   }
 
   @override
@@ -173,13 +169,11 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
     );
   }
 
- codex/add-telemetry-service-hooks-to-core_progress_section
-
   Future<void> _configureAudioPlayer() async {
     await _audioPlayer.setReleaseMode(ReleaseMode.stop);
     if (!kIsWeb) {
       await _audioPlayer.setAudioContext(
-        const AudioContext(
+        AudioContext(
           android: AudioContextAndroid(
             isSpeakerphoneOn: false,
             stayAwake: false,
@@ -195,8 +189,6 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
       );
     }
   }
-
- gpt
   ProgressFeedbackHooks _mergedFeedbackHooks() {
     final external = widget.feedbackHooks;
 


### PR DESCRIPTION
## Summary
- add the audioplayers platform interface import so Android and iOS audio context types resolve
- remove the const constructor call when configuring the audio context to match the plugin API

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904fa7885b4832dbe0b010dbfd133ed