### PR TITLE
Clean up progress audio setup

### DIFF
--- a/lib/features/progress/widgets/core_progress_section.dart
+++ b/lib/features/progress/widgets/core_progress_section.dart
@@ -1,11 +1,7 @@
 import 'dart:async';
 
 import 'package:audioplayers/audioplayers.dart';
- codex/fix-100+-errors-in-current-project-ofm0nj
-
-import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
 import 'package:flutter/foundation.dart';
- gpt
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -94,15 +90,8 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
   void initState() {
     super.initState();
     _windowKey = _windowKeyFor(widget.progress);
- codex/fix-100+-errors-in-current-project-ofm0nj
     _audioPlayer = AudioPlayer(playerId: 'progress_feedback_$hashCode');
-    unawaited(_audioPlayer.setReleaseMode(ReleaseMode.stop));
-
-    _audioPlayer = AudioPlayer(playerId: 'progress_feedback_${hashCode}');
-    unawaited(_audioPlayer.setReleaseMode(ReleaseMode.stop));
-
     unawaited(_configureAudioPlayer());
- gpt
   }
 
   @override
@@ -177,29 +166,12 @@ class _CoreProgressSectionState extends State<CoreProgressSection> {
     );
   }
 
- codex/fix-100+-errors-in-current-project-ofm0nj
-
   Future<void> _configureAudioPlayer() async {
     await _audioPlayer.setReleaseMode(ReleaseMode.stop);
-    if (!kIsWeb) {
-      await _audioPlayer.setAudioContext(
-        AudioContext(
-          android: AudioContextAndroid(
-            isSpeakerphoneOn: false,
-            stayAwake: false,
-            contentType: AndroidAudioContentType.sonification,
-            usageType: AndroidAudioUsageType.assistanceSonification,
-            audioFocus: AndroidAudioFocus.gainTransientMayDuck,
-          ),
-          iOS: AudioContextIOS(
-            category: AVAudioSessionCategory.ambient,
-            options: {AVAudioSessionOptions.mixWithOthers},
-          ),
-        ),
-      );
-    }
+    await _audioPlayer.setPlayerMode(
+      kIsWeb ? PlayerMode.mediaPlayer : PlayerMode.lowLatency,
+    );
   }
- gpt
   ProgressFeedbackHooks _mergedFeedbackHooks() {
     final external = widget.feedbackHooks;
 


### PR DESCRIPTION
## Summary
- remove stray placeholder markers that broke the core progress section source
- simplify the audio player configuration to rely on built-in player mode without importing the platform interface package

## Testing
- flutter analyze *(fails: Flutter SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_69050097b0dc832dbec5026e33024deb