### PR TITLE
Add dashboard completion telemetry and integrate training day tracking

### DIFF
--- a/lib/features/common/state/dashboard_view_model.dart
+++ b/lib/features/common/state/dashboard_view_model.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:free_base/features/calendar/notifier/calendar_notifier.dart';
+import 'package:free_base/features/common/utils/day_completion_util.dart';
 import 'package:free_base/features/progress/models/week_progress.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/services/reminder/reminder_service.dart';
+import 'package:free_base/services/telemetry/telemetry_service.dart';
 
 class DashboardViewModel extends ChangeNotifier {
   static const int _xpPerLevel = 100;
@@ -13,11 +17,13 @@ class DashboardViewModel extends ChangeNotifier {
     ReminderService reminderService, {
     bool autoplayEnabled = true,
     bool audioEnabled = true,
+    TelemetryService? telemetryService,
   })  : _sessionNotifier = sessionNotifier,
         _calendarNotifier = calendarNotifier,
         _reminderService = reminderService,
         _autoplayEnabled = autoplayEnabled,
-        _audioEnabled = audioEnabled {
+        _audioEnabled = audioEnabled,
+        _telemetry = telemetryService {
     _sessionNotifier.addListener(_sessionListener);
     _calendarNotifier.addListener(_calendarListener);
     _reminderService.addListener(_reminderListener);
@@ -26,6 +32,7 @@ class DashboardViewModel extends ChangeNotifier {
   late SessionNotifier _sessionNotifier;
   late CalendarNotifier _calendarNotifier;
   late ReminderService _reminderService;
+  TelemetryService? _telemetry;
   bool _autoplayEnabled = true;
   bool _audioEnabled = true;
 
@@ -33,6 +40,7 @@ class DashboardViewModel extends ChangeNotifier {
     SessionNotifier sessionNotifier,
     CalendarNotifier calendarNotifier,
     ReminderService reminderService,
+    TelemetryService telemetryService,
   ) {
     if (!identical(_sessionNotifier, sessionNotifier)) {
       _sessionNotifier.removeListener(_sessionListener);
@@ -48,6 +56,9 @@ class DashboardViewModel extends ChangeNotifier {
       _reminderService.removeListener(_reminderListener);
       _reminderService = reminderService;
       _reminderService.addListener(_reminderListener);
+    }
+    if (!identical(_telemetry, telemetryService)) {
+      _telemetry = telemetryService;
     }
     notifyListeners();
   }
@@ -116,8 +127,9 @@ class DashboardViewModel extends ChangeNotifier {
   }
 
   Future<bool> startNextWeek() async {
+    final progress = currentWeekProgress;
     final nextWeekStart =
-        currentWeekProgress.windowEnd.add(const Duration(days: 1));
+        progress.windowEnd.add(const Duration(days: 1));
     final normalized = DateTime(
       nextWeekStart.year,
       nextWeekStart.month,
@@ -128,6 +140,22 @@ class DashboardViewModel extends ChangeNotifier {
       ensureWeekForDay: normalized,
     );
     _calendarNotifier.selectDay(normalized);
+
+    final telemetry = _telemetry;
+    if (telemetry != null) {
+      final stats = progress.stats;
+      unawaited(
+        telemetry.logEvent(
+          'dashboard_start_next_week',
+          properties: {
+            'next_week_start': normalized.toIso8601String(),
+            'planned_days': stats.plannedDays,
+            'completed_days': stats.completedDays,
+            'pending_reflections': stats.pendingReflections,
+          },
+        ),
+      );
+    }
     return true;
   }
 
@@ -140,6 +168,21 @@ class DashboardViewModel extends ChangeNotifier {
         break;
       }
     }
+
+    final telemetry = _telemetry;
+    if (telemetry != null) {
+      final stats = progress.stats;
+      unawaited(
+        telemetry.logEvent(
+          'dashboard_open_reflection',
+          properties: {
+            'has_pending': pending != null,
+            'target_date': pending?.date.toIso8601String(),
+            'pending_reflections': stats.pendingReflections,
+          },
+        ),
+      );
+    }
     if (pending == null) {
       return false;
     }
@@ -149,6 +192,39 @@ class DashboardViewModel extends ChangeNotifier {
     );
     _calendarNotifier.selectDay(pending.date);
     return true;
+  }
+
+  Future<DayCompletionResult> markTodayComplete({
+    DateTime? completionTime,
+    int? xpReward,
+  }) async {
+    final completion = (completionTime ?? DateTime.now()).toLocal();
+    final result = await markDayCompletion(
+      sessionNotifier: _sessionNotifier,
+      calendarNotifier: _calendarNotifier,
+      completionTime: completion,
+      xpReward: xpReward,
+    );
+
+    final telemetry = _telemetry;
+    if (telemetry != null) {
+      final stats = currentWeekProgress.stats;
+      unawaited(
+        telemetry.logEvent(
+          'dashboard_mark_today_complete',
+          properties: {
+            'completion_date': result.date.toIso8601String(),
+            'already_completed': result.wasAlreadyCompleted,
+            'requires_reflection': result.requiresReflection,
+            'pending_reflections': stats.pendingReflections,
+            'daily_xp': _sessionNotifier.state.dailyXp,
+            'streak_count': _sessionNotifier.state.streakCount,
+          },
+        ),
+      );
+    }
+
+    return result;
   }
 
   CoreWeekProgress _calculateCurrentWeekProgress() {

--- a/lib/features/common/utils/day_completion_util.dart
+++ b/lib/features/common/utils/day_completion_util.dart
@@ -1,0 +1,58 @@
+import 'package:free_base/features/calendar/notifier/calendar_notifier.dart';
+import 'package:free_base/features/training/notifier/session_notifier.dart';
+
+class DayCompletionResult {
+  const DayCompletionResult({
+    required this.date,
+    required this.wasAlreadyCompleted,
+    required this.requiresReflection,
+  });
+
+  final DateTime date;
+  final bool wasAlreadyCompleted;
+  final bool requiresReflection;
+}
+
+Future<DayCompletionResult> markDayCompletion({
+  required SessionNotifier sessionNotifier,
+  required CalendarNotifier calendarNotifier,
+  required DateTime completionTime,
+  int? xpReward,
+}) async {
+  final localCompletion = completionTime.toLocal();
+  final normalized = DateTime(
+    localCompletion.year,
+    localCompletion.month,
+    localCompletion.day,
+  );
+
+  if (xpReward != null && xpReward > 0) {
+    sessionNotifier.applyXpReward(
+      xp: xpReward,
+      completionTime: localCompletion,
+    );
+  } else {
+    final lastCompleted = sessionNotifier.state.lastCompletedOn;
+    final alreadyTracked = lastCompleted != null &&
+        lastCompleted.year == normalized.year &&
+        lastCompleted.month == normalized.month &&
+        lastCompleted.day == normalized.day;
+    if (!alreadyTracked) {
+      sessionNotifier.state = sessionNotifier.state.copyWith(
+        lastCompletedOn: normalized,
+      );
+      sessionNotifier.updateStreakFreeze(referenceDate: normalized);
+    }
+  }
+
+  final alreadyCompleted = calendarNotifier.dayIsCompleted(normalized);
+  if (!alreadyCompleted) {
+    await calendarNotifier.toggleDayCompleted(normalized);
+  }
+
+  return DayCompletionResult(
+    date: normalized,
+    wasAlreadyCompleted: alreadyCompleted,
+    requiresReflection: calendarNotifier.requiresReflection(normalized),
+  );
+}

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import 'package:free_base/features/common/state/dashboard_view_model.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/training_intent.dart';
@@ -367,6 +368,12 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
         context.read<SessionNotifier>().applyXpReward(xp: ex.xpReward);
         await MoroProgressStore.markCompleted(ex.index, totalExercises);
         await _refreshProgress(totalExercises);
+        if (!context.mounted) return;
+        if (!result.hasNextExercise) {
+          await context.read<DashboardViewModel>().markTodayComplete(
+                completionTime: DateTime.now().toLocal(),
+              );
+        }
         if (result.hasNextExercise && result.autoplayEnabled) {
           final nextIndex = ex.index + 1;
           final nextExercise = allExercises.firstWhere(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -270,17 +270,22 @@ class _MyAppState extends State<MyApp> {
             cacheBox: widget.cosmeticsBox,
           ),
         ),
-        ChangeNotifierProxyProvider3<SessionNotifier, CalendarNotifier,
-            ReminderService, DashboardViewModel>(
+        ChangeNotifierProxyProvider4<SessionNotifier, CalendarNotifier,
+            ReminderService, TelemetryService, DashboardViewModel>(
           create: (ctx) => DashboardViewModel(
             ctx.read<SessionNotifier>(),
             ctx.read<CalendarNotifier>(),
             ctx.read<ReminderService>(),
+            telemetryService: ctx.read<TelemetryService>(),
           ),
-          update: (ctx, session, calendar, reminder, previous) {
-            final model = previous ??
-                DashboardViewModel(session, calendar, reminder);
-            model.updateSources(session, calendar, reminder);
+          update: (ctx, session, calendar, reminder, telemetry, previous) {
+            final model = previous ?? DashboardViewModel(
+              session,
+              calendar,
+              reminder,
+              telemetryService: telemetry,
+            );
+            model.updateSources(session, calendar, reminder, telemetry);
             return model;
           },
         ),


### PR DESCRIPTION
## Summary
- extend `DashboardViewModel` with telemetry-aware actions for starting the next week, opening reflections, and marking daily completion
- add a shared day completion utility that keeps calendar progress and session streak data in sync
- trigger the dashboard day completion hook after finishing the Moro training flow

## Testing
- not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6905050ae5a8832da8303f7c3e4c9636