### PR TITLE
Fix nullable Hive reads in progress store

### DIFF
--- a/lib/features/progress/state/progress_store.dart
+++ b/lib/features/progress/state/progress_store.dart
@@ -10,14 +10,14 @@ class ProgressStore extends ChangeNotifier {
   /// Returns `true` if the given [day] was marked as completed.
   bool isDayCompleted(DateTime day) {
     final key = _keyFor(day);
-    return _box.get(key, defaultValue: false);
+    return _box.get(key, defaultValue: false) ?? false;
   }
 
   /// Sets the completion status for the given [day].
   Future<void> setDayCompleted(DateTime day, bool completed) async {
     final normalized = _normalize(day);
     final key = _keyFor(normalized);
-    final current = _box.get(key, defaultValue: false);
+    final current = _box.get(key, defaultValue: false) ?? false;
     if (current == completed) {
       return;
     }
@@ -33,7 +33,7 @@ class ProgressStore extends ChangeNotifier {
   Future<void> toggleDayCompleted(DateTime day) async {
     final normalized = _normalize(day);
     final key = _keyFor(normalized);
-    final current = _box.get(key, defaultValue: false);
+    final current = _box.get(key, defaultValue: false) ?? false;
     if (current) {
       await _box.delete(key);
     } else {


### PR DESCRIPTION
## Summary
- ensure the progress store normalizes nullable Hive reads to non-null booleans to prevent runtime and analysis issues

## Testing
- not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_6905139918a0832d8ad78368174e292e