### PR TITLE
Remove training navigation shortcut from bottom bar

### DIFF
--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -43,7 +43,6 @@ class AppRouter {
 
   static final _rootNavigatorKey = GlobalKey<NavigatorState>();
   static final _dashboardNavigatorKey = GlobalKey<NavigatorState>();
-  static final _trainingNavigatorKey = GlobalKey<NavigatorState>();
   static final _profileNavigatorKey = GlobalKey<NavigatorState>();
 
   final GoRouter router;
@@ -127,53 +126,6 @@ class AppRouter {
             ],
           ),
           StatefulShellBranch(
-            navigatorKey: _trainingNavigatorKey,
-            initialLocation: AppRoutePaths.training,
-            routes: [
-              GoRoute(
-                path: AppRoutePaths.training,
-                name: AppRouteNames.training,
-                builder: (context, state) {
-                  final extra = state.extra;
-                  return MoroTrainingScreen(
-                    intent: extra is TrainingIntent ? extra : null,
-                  );
-                },
-                routes: [
-                  GoRoute(
-                    path: 'completed',
-                    name: AppRouteNames.trainingCompleted,
-                    builder: (context, state) => const TrainingCompletedScreen(),
-                  ),
-                  GoRoute(
-                    path: 'moro/precheck',
-                    name: AppRouteNames.moroPrecheck,
-                    builder: (context, state) => const MoroPreCheckScreen(),
-                  ),
-                  GoRoute(
-                    path: 'moro/:exerciseId',
-                    name: AppRouteNames.moroExercise,
-                    builder: (context, state) {
-                      final args = state.extra;
-                      if (args is MoroExerciseScreenArgs) {
-                        return MoroExerciseScreen(
-                          exercise: args.exercise,
-                          offset: args.offset,
-                          autoplay: args.autoplay,
-                          autoplayDelaySeconds: args.autoplayDelaySeconds,
-                          totalExercises: args.totalExercises,
-                        );
-                      }
-                      return const ErrorScreen(
-                        message: 'Ungültige Trainingsparameter.',
-                      );
-                    },
-                  ),
-                ],
-              ),
-            ],
-          ),
-          StatefulShellBranch(
             navigatorKey: _profileNavigatorKey,
             initialLocation: AppRoutePaths.profile,
             routes: [
@@ -211,6 +163,51 @@ class AppRouter {
                 ],
               ),
             ],
+          ),
+        ],
+      ),
+      GoRoute(
+        path: AppRoutePaths.training,
+        name: AppRouteNames.training,
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) {
+          final extra = state.extra;
+          return MoroTrainingScreen(
+            intent: extra is TrainingIntent ? extra : null,
+          );
+        },
+        routes: [
+          GoRoute(
+            path: 'completed',
+            name: AppRouteNames.trainingCompleted,
+            parentNavigatorKey: _rootNavigatorKey,
+            builder: (context, state) => const TrainingCompletedScreen(),
+          ),
+          GoRoute(
+            path: 'moro/precheck',
+            name: AppRouteNames.moroPrecheck,
+            parentNavigatorKey: _rootNavigatorKey,
+            builder: (context, state) => const MoroPreCheckScreen(),
+          ),
+          GoRoute(
+            path: 'moro/:exerciseId',
+            name: AppRouteNames.moroExercise,
+            parentNavigatorKey: _rootNavigatorKey,
+            builder: (context, state) {
+              final args = state.extra;
+              if (args is MoroExerciseScreenArgs) {
+                return MoroExerciseScreen(
+                  exercise: args.exercise,
+                  offset: args.offset,
+                  autoplay: args.autoplay,
+                  autoplayDelaySeconds: args.autoplayDelaySeconds,
+                  totalExercises: args.totalExercises,
+                );
+              }
+              return const ErrorScreen(
+                message: 'Ungültige Trainingsparameter.',
+              );
+            },
           ),
         ],
       ),

--- a/lib/services/app_shell.dart
+++ b/lib/services/app_shell.dart
@@ -27,11 +27,6 @@ class AppShell extends StatelessWidget {
             label: 'Dashboard',
           ),
           NavigationDestination(
-            icon: Icon(Icons.fitness_center_outlined),
-            selectedIcon: Icon(Icons.fitness_center),
-            label: 'Training',
-          ),
-          NavigationDestination(
             icon: Icon(Icons.person_outline),
             selectedIcon: Icon(Icons.person),
             label: 'Profil',


### PR DESCRIPTION
## Summary
- remove the training tab from the bottom navigation bar so routing happens from the dashboard
- move the training flow routes outside of the shell navigation to keep them accessible without a tab

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69060dc98e80832da38b2482945d9d24