### PR TITLE
Ensure onboarding starts on dashboard

### DIFF
--- a/lib/features/common/splash_screen.dart
+++ b/lib/features/common/splash_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import 'package:free_base/features/common/dashboard_route_args.dart';
 import 'package:free_base/features/onboarding/services/secure_storage_service.dart';
 import 'package:free_base/features/onboarding/state/consent_notifier.dart';
 import 'package:free_base/features/training/services/session_repository.dart';
@@ -44,11 +45,17 @@ class _SplashScreenState extends State<SplashScreen> {
 
       final onboardingComplete = sessionState?.onboardingComplete ?? false;
       if (!onboardingComplete) {
-        context.goNamed(AppRouteNames.training);
+        context.goNamed(
+          AppRouteNames.dashboard,
+          extra: const DashboardRouteArgs(),
+        );
         return;
       }
 
-      context.goNamed(AppRouteNames.dashboard);
+      context.goNamed(
+        AppRouteNames.dashboard,
+        extra: const DashboardRouteArgs(),
+      );
     } else {
       context.goNamed(AppRouteNames.login);
     }

--- a/lib/services/app_route_guard.dart
+++ b/lib/services/app_route_guard.dart
@@ -103,7 +103,8 @@ class AppRouteGuard {
   }
 
   bool _requiresOnboardingComplete(String location) {
-    if (location == AppRoutePaths.training ||
+    if (location == AppRoutePaths.splash ||
+        location == AppRoutePaths.training ||
         location == AppRoutePaths.trainingCompleted ||
         location == AppRoutePaths.dashboard ||
         location == AppRoutePaths.consent ||


### PR DESCRIPTION
## Summary
- route authenticated users without completed onboarding from the splash screen to the dashboard shell
- exempt the splash route from onboarding enforcement to avoid redirecting to the disconnected training flow on startup

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69060f5e7c98832d9babc8547a113984