### PR TITLE
Redirect dashboard precheck cancel back to dashboard

### DIFF
--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -152,6 +152,10 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
   ) async {
     final result = await context.pushNamed(AppRouteNames.moroPrecheck);
     if (result is! MoroPreCheckResult) {
+      final intent = widget.intent;
+      if (intent?.type == TrainingIntentType.start && mounted) {
+        context.goNamed(AppRouteNames.dashboard);
+      }
       return;
     }
     setState(() {


### PR DESCRIPTION
## Summary
- redirect Moro pre-check cancellation triggered from the dashboard start intent back to the dashboard so the legacy training screen is skipped

## Testing
- flutter test test/features/training/moro/moro_training_screen_test.dart *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6906107cc8b4832d8381767118e0361c