### PR TITLE
Add Moro exercise fallback handling and coverage

### DIFF
--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -15,6 +16,8 @@ import 'moro_progress_store.dart';
 import 'moro_repository.dart';
 import 'moro_speed_store.dart';
 import 'pre_check_screen.dart';
+
+enum _MoroExerciseLaunchSource { start, autoplay, resume }
 
 class MoroTrainingScreen extends StatefulWidget {
   final TrainingIntent? intent;
@@ -167,7 +170,14 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     final startExercise = _determineStartExercise(items, progress, notifier);
     final offset = await _getOffset(startExercise.index);
     if (!mounted) return;
-    await _openExercise(context, startExercise, offset, items.length, items);
+    await _openExercise(
+      context,
+      startExercise,
+      offset,
+      items.length,
+      items,
+      source: _MoroExerciseLaunchSource.start,
+    );
   }
 
   @override
@@ -314,6 +324,7 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
                                                 offs,
                                                 items.length,
                                                 items,
+                                                source: _MoroExerciseLaunchSource.start,
                                               )
                                           : null,
                                       icon: const Icon(Icons.play_arrow),
@@ -352,19 +363,26 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     MoroExercise ex,
     int offset,
     int totalExercises,
-    List<MoroExercise> allExercises,
-  ) async {
+    List<MoroExercise> allExercises, {
+    _MoroExerciseLaunchSource source = _MoroExerciseLaunchSource.start,
+  }) async {
     context.read<SessionNotifier>().startMoroSession();
+    final args = MoroExerciseScreenArgs(
+      exercise: ex,
+      offset: offset,
+      autoplay: _autoplayEnabled,
+      autoplayDelaySeconds: _autoplayDelaySeconds,
+      totalExercises: totalExercises,
+    );
+    developer.log(
+      'Opening Moro exercise ${ex.index} via ${source.name} '
+      '(offset=$offset autoplay=${args.autoplay} delay=${args.autoplayDelaySeconds})',
+      name: 'MoroTrainingScreen',
+    );
     final result = await context.pushNamed(
       AppRouteNames.moroExercise,
       pathParameters: {'exerciseId': '${ex.index}'},
-      extra: MoroExerciseScreenArgs(
-        exercise: ex,
-        offset: offset,
-        autoplay: _autoplayEnabled,
-        autoplayDelaySeconds: _autoplayDelaySeconds,
-        totalExercises: totalExercises,
-      ),
+      extra: args,
     );
     if (!context.mounted) return;
     if (result is MoroExerciseResult) {
@@ -392,6 +410,7 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
             nextOffset,
             totalExercises,
             allExercises,
+            source: _MoroExerciseLaunchSource.autoplay,
           );
           return;
         }
@@ -454,7 +473,14 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     }
     final offset = await _getOffset(exercise.index);
     if (!mounted) return;
-    await _openExercise(context, exercise, offset, items.length, items);
+    await _openExercise(
+      context,
+      exercise,
+      offset,
+      items.length,
+      items,
+      source: _MoroExerciseLaunchSource.resume,
+    );
   }
 
   String? _resolveResumeKey(

--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -20,6 +22,8 @@ import 'package:free_base/features/questionnaire/questionnaire_result_screen.dar
 import 'package:free_base/features/questionnaire/questionnaire_screen.dart';
 import 'package:free_base/features/questionnaire/quiz_intro_screen.dart';
 import 'package:free_base/features/training/moro/moro_exercise_screen.dart';
+import 'package:free_base/features/training/moro/moro_repository.dart';
+import 'package:free_base/features/training/moro/moro_speed_store.dart';
 import 'package:free_base/features/training/moro/pre_check_screen.dart';
 import 'package:free_base/features/training/moro/moro_training_screen.dart';
 import 'package:free_base/features/training/training_completed_screen.dart';
@@ -204,8 +208,23 @@ class AppRouter {
                   totalExercises: args.totalExercises,
                 );
               }
-              return const ErrorScreen(
-                message: 'Ungültige Trainingsparameter.',
+              final idParam = state.pathParameters['exerciseId'];
+              final exerciseId = int.tryParse(idParam ?? '');
+              if (exerciseId == null) {
+                developer.log(
+                  'Failed to parse exerciseId "$idParam" for MoroExercise route without extra.',
+                  name: 'AppRouter',
+                );
+                return const ErrorScreen(
+                  message: 'Ungültige Trainingsparameter.',
+                );
+              }
+              developer.log(
+                'Missing MoroExerciseScreenArgs for exercise $exerciseId – loading fallback.',
+                name: 'AppRouter',
+              );
+              return MoroExerciseRouteLoader(
+                exerciseId: exerciseId,
               );
             },
           ),
@@ -246,5 +265,76 @@ class AppRouter {
         },
       ),
     ];
+  }
+}
+
+class MoroExerciseRouteLoader extends StatelessWidget {
+  final int exerciseId;
+  final MoroRepository? repository;
+  final Widget Function(MoroExerciseScreenArgs args)? screenBuilder;
+
+  const MoroExerciseRouteLoader({
+    super.key,
+    required this.exerciseId,
+    this.repository,
+    this.screenBuilder,
+  });
+
+  Future<MoroExerciseScreenArgs> _loadArgs() async {
+    final repo = repository ?? MoroRepository();
+    final exercises = await repo.load();
+    MoroExercise? exercise;
+    for (final ex in exercises) {
+      if (ex.index == exerciseId) {
+        exercise = ex;
+        break;
+      }
+    }
+    if (exercise == null) {
+      throw StateError('Moro exercise $exerciseId nicht gefunden.');
+    }
+    final offset = await MoroSpeedStore.getOffsetForExercise(exercise.index);
+    return MoroExerciseScreenArgs(
+      exercise: exercise,
+      offset: offset,
+      autoplay: true,
+      autoplayDelaySeconds: exercise.autoplayDefault,
+      totalExercises: exercises.length,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<MoroExerciseScreenArgs>(
+      future: _loadArgs(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        if (!snapshot.hasData || snapshot.hasError) {
+          developer.log(
+            'Fallback für Moro-Training fehlgeschlagen: ${snapshot.error}',
+            name: 'AppRouter',
+          );
+          return const ErrorScreen(
+            message: 'Das Training konnte nicht geladen werden.',
+          );
+        }
+        final args = snapshot.data!;
+        final builder = screenBuilder;
+        if (builder != null) {
+          return builder(args);
+        }
+        return MoroExerciseScreen(
+          exercise: args.exercise,
+          offset: args.offset,
+          autoplay: args.autoplay,
+          autoplayDelaySeconds: args.autoplayDelaySeconds,
+          totalExercises: args.totalExercises,
+        );
+      },
+    );
   }
 }

--- a/test/features/training/moro/moro_training_screen_test.dart
+++ b/test/features/training/moro/moro_training_screen_test.dart
@@ -8,12 +8,16 @@ import 'package:provider/provider.dart';
 
 import 'package:free_base/features/training/models/exercise_item.dart';
 import 'package:free_base/features/training/models/session_state.dart';
+import 'package:free_base/features/training/moro/moro_exercise_screen.dart';
+import 'package:free_base/features/training/moro/moro_models.dart';
+import 'package:free_base/features/training/moro/moro_repository.dart';
 import 'package:free_base/features/training/moro/moro_training_screen.dart';
 import 'package:free_base/features/training/moro/pre_check_screen.dart';
 import 'package:free_base/features/training/notifier/session_notifier.dart';
 import 'package:free_base/features/training/services/exercise_repository.dart';
 import 'package:free_base/features/training/services/session_repository.dart';
 import 'package:free_base/features/training/services/sync_service.dart';
+import 'package:free_base/services/app_router.dart';
 import 'package:free_base/services/app_routes.dart';
 import 'package:free_base/services/training_intent.dart';
 
@@ -52,6 +56,43 @@ class _TestExerciseRepository extends ExerciseRepository {
 
   @override
   List<ExerciseItem> getExercisesForPhase(String phaseId) => _items;
+}
+
+class _FakeMoroRepository extends MoroRepository {
+  final List<MoroExercise> _items;
+
+  _FakeMoroRepository(this._items);
+
+  @override
+  Future<List<MoroExercise>> load() async => _items;
+}
+
+List<MoroExercise> _buildFakeExercises(int count) {
+  return List.generate(count, (index) {
+    final idx = index + 1;
+    return MoroExercise(
+      index: idx,
+      title: 'Übung $idx',
+      type: MoroExerciseType.simple,
+      repeats: 1,
+      phasesPerRepeat: 1,
+      baseSeconds: 5,
+      autoplayDefault: 3,
+      goal: 'Ziel $idx',
+      startPosition: 'Start',
+      steps: const [],
+      cues: const [],
+      breath: const MoroBreathPattern(pattern: 'breath'),
+      abortRules: const [],
+      notes: null,
+      tags: const [],
+      version: '1.0.0',
+      media: const MoroMedia(),
+      resumeKey: 'moro_$idx',
+      mediaFallbackImage: null,
+      xpReward: 10,
+    );
+  });
 }
 
 SessionNotifier _createNotifier() {
@@ -135,7 +176,53 @@ class _StubExerciseScreen extends StatelessWidget {
   }
 }
 
-GoRouter _createRouter(ValueNotifier<int> counter) {
+class _FallbackStubExerciseScreen extends StatefulWidget {
+  const _FallbackStubExerciseScreen({
+    required this.args,
+    required this.visited,
+    this.popResult,
+  });
+
+  final MoroExerciseScreenArgs args;
+  final List<int> visited;
+  final MoroExerciseResult? popResult;
+
+  @override
+  State<_FallbackStubExerciseScreen> createState() =>
+      _FallbackStubExerciseScreenState();
+}
+
+class _FallbackStubExerciseScreenState
+    extends State<_FallbackStubExerciseScreen> {
+  @override
+  void initState() {
+    super.initState();
+    widget.visited.add(widget.args.exercise.index);
+    final result = widget.popResult;
+    if (result != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        Navigator.of(context).pop(result);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text('fallback-${widget.args.exercise.index}'),
+      ),
+    );
+  }
+}
+
+GoRouter _createRouter(
+  ValueNotifier<int> counter, {
+  bool useFallback = false,
+  MoroRepository? repository,
+  Widget Function(MoroExerciseScreenArgs args)? fallbackBuilder,
+}) {
   return GoRouter(
     initialLocation: '/',
     routes: [
@@ -160,6 +247,14 @@ GoRouter _createRouter(ValueNotifier<int> counter) {
                 name: AppRouteNames.moroExercise,
                 builder: (context, state) {
                   final id = state.pathParameters['exerciseId']!;
+                  if (useFallback) {
+                    final exerciseId = int.tryParse(id) ?? 0;
+                    return MoroExerciseRouteLoader(
+                      exerciseId: exerciseId,
+                      repository: repository,
+                      screenBuilder: fallbackBuilder,
+                    );
+                  }
                   return _StubExerciseScreen(
                     exerciseId: id,
                   );
@@ -188,6 +283,12 @@ void main() {
     }
     try {
       await Hive.deleteBoxFromDisk('moro_progress');
+    } catch (_) {}
+    if (Hive.isBoxOpen('moro_speed_offsets')) {
+      await Hive.box('moro_speed_offsets').close();
+    }
+    try {
+      await Hive.deleteBoxFromDisk('moro_speed_offsets');
     } catch (_) {}
   });
 
@@ -244,5 +345,123 @@ void main() {
 
     expect(counter.value, 0);
     expect(find.text('exercise-2'), findsOneWidget);
+  });
+
+  testWidgets('fallback opens exercise when args missing on start', (tester) async {
+    final notifier = _createNotifier();
+    final counter = ValueNotifier<int>(0);
+    final visited = <int>[];
+    final repo = _FakeMoroRepository(_buildFakeExercises(3));
+    final router = _createRouter(
+      counter,
+      useFallback: true,
+      repository: repo,
+      fallbackBuilder: (args) => _FallbackStubExerciseScreen(
+        args: args,
+        visited: visited,
+      ),
+    );
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SessionNotifier>.value(
+        value: notifier,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    router.goNamed(AppRouteNames.training, extra: TrainingIntent.start());
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(counter.value, greaterThanOrEqualTo(1));
+    expect(visited, equals([1]));
+    expect(find.text('fallback-1'), findsOneWidget);
+  });
+
+  testWidgets('fallback resume opens stored exercise without args', (tester) async {
+    final notifier = _createNotifier();
+    notifier.saveResumePoint('moro_2', const {
+      'stage': 'active',
+      'repeatIdx': 1,
+      'phaseIdx': 1,
+      'remainingMs': 5000,
+    });
+    final counter = ValueNotifier<int>(0);
+    final visited = <int>[];
+    final repo = _FakeMoroRepository(_buildFakeExercises(3));
+    final router = _createRouter(
+      counter,
+      useFallback: true,
+      repository: repo,
+      fallbackBuilder: (args) => _FallbackStubExerciseScreen(
+        args: args,
+        visited: visited,
+      ),
+    );
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SessionNotifier>.value(
+        value: notifier,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    router.goNamed(AppRouteNames.training, extra: TrainingIntent.resume('moro_2'));
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(counter.value, 0);
+    expect(visited, equals([2]));
+    expect(find.text('fallback-2'), findsOneWidget);
+  });
+
+  testWidgets('fallback handles autoplay navigation without args', (tester) async {
+    final notifier = _createNotifier();
+    final counter = ValueNotifier<int>(0);
+    final visited = <int>[];
+    final repo = _FakeMoroRepository(_buildFakeExercises(3));
+    final router = _createRouter(
+      counter,
+      useFallback: true,
+      repository: repo,
+      fallbackBuilder: (args) {
+        final shouldAutoplay = args.exercise.index == 1;
+        return _FallbackStubExerciseScreen(
+          args: args,
+          visited: visited,
+          popResult: shouldAutoplay
+              ? MoroExerciseResult(
+                  completed: true,
+                  autoplayEnabled: true,
+                  autoplayDelaySeconds: args.autoplayDelaySeconds,
+                  exerciseIndex: args.exercise.index,
+                  hasNextExercise: true,
+                )
+              : null,
+        );
+      },
+    );
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<SessionNotifier>.value(
+        value: notifier,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    router.goNamed(AppRouteNames.training, extra: TrainingIntent.start());
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    // allow autoplay result to propagate and open next exercise
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(counter.value, greaterThanOrEqualTo(1));
+    expect(visited, equals([1, 2]));
+    expect(find.text('fallback-2'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- log the launch source whenever a Moro exercise is opened
- add a Moro exercise route fallback that loads the exercise by id when no extra args are supplied
- add widget/router tests that exercise the fallback for start, resume, and autoplay flows

## Testing
- flutter test test/features/training/moro/moro_training_screen_test.dart *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_690625a86de4832da8f9bf94a32076e0