### PR TITLE
Fix missing MoroExercise import for route loader

### DIFF
--- a/lib/services/app_router.dart
+++ b/lib/services/app_router.dart
@@ -22,6 +22,7 @@ import 'package:free_base/features/questionnaire/questionnaire_result_screen.dar
 import 'package:free_base/features/questionnaire/questionnaire_screen.dart';
 import 'package:free_base/features/questionnaire/quiz_intro_screen.dart';
 import 'package:free_base/features/training/moro/moro_exercise_screen.dart';
+import 'package:free_base/features/training/moro/moro_models.dart';
 import 'package:free_base/features/training/moro/moro_repository.dart';
 import 'package:free_base/features/training/moro/moro_speed_store.dart';
 import 'package:free_base/features/training/moro/pre_check_screen.dart';


### PR DESCRIPTION
## Summary
- add the MoroExercise model import to the app router so the fallback route loader can compile

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_69062a220b64832db5ad31920d15c90d