### PR TITLE
Fix Moro exercise screen default media service initialization

### DIFF
--- a/lib/features/training/moro/media_player_service.dart
+++ b/lib/features/training/moro/media_player_service.dart
@@ -23,6 +23,8 @@ class MoroMediaLoadResult {
 }
 
 class MoroMediaPlayerService {
+  const MoroMediaPlayerService();
+
   Future<MoroMediaLoadResult> loadForExercise(MoroExercise exercise) async {
     String? videoAsset;
     String? imageAsset = exercise.media.image ?? exercise.mediaFallbackImage;

--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -74,7 +74,7 @@ class MoroExerciseScreen extends StatefulWidget {
     required this.autoplayDelaySeconds,
     required this.totalExercises,
     MoroMediaPlayerService? mediaService,
-  }) : mediaService = mediaService ?? MoroMediaPlayerService();
+  }) : mediaService = mediaService ?? const MoroMediaPlayerService();
 
   @override
   State<MoroExerciseScreen> createState() => _MoroExerciseScreenState();


### PR DESCRIPTION
## Summary
- add a const constructor to `MoroMediaPlayerService`
- use the const media service when defaulting the Moro exercise screen's dependency

## Testing
- not run (Flutter tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_6906515ee5e0832d91390184306dde5c