### PR TITLE
Remove blocking preparation checklists in Moro training

### DIFF
--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -51,6 +51,9 @@ const _preCheckItems = [
   'Beine parallel, nicht überkreuzen',
   'Handflächen flach/offen auflegen',
   'Augen offen',
+  'Matte bereitgelegt',
+  'Timer-Sound aktiv',
+  'Musik aus / Fokusmodus',
 ];
 
 const _safetyNotice =
@@ -87,10 +90,6 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
   bool _mediaLoading = true;
   bool _mediaErrorAcknowledged = false;
 
-  late final Map<int, bool> _checkStates;
-  bool _matReady = false;
-  bool _timerSound = true;
-  bool _musicOff = true;
   double _tensionValue = 5;
   double _painValue = 1;
 
@@ -104,9 +103,6 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
     super.initState();
     _notesController = TextEditingController();
     _mediaService = widget.mediaService;
-    _checkStates = {
-      for (var i = 0; i < _preCheckItems.length; i++) i: false,
-    };
     _loadMedia();
   }
 
@@ -271,45 +267,37 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
               'Stopp bei Schmerzen oder Taubheitsgefühl – Sicherheit hat Vorrang.',
         ),
         const SizedBox(height: 12),
-        ..._preCheckItems.asMap().entries.map(
-          (entry) => CheckboxListTile(
-            value: _checkStates[entry.key],
-            onChanged: (v) => setState(() => _checkStates[entry.key] = v ?? false),
-            title: Text(entry.value),
+        ..._preCheckItems.map(
+          (item) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4.0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.only(top: 2.0),
+                  child: Icon(Icons.check_circle_outline, size: 20),
+                ),
+                const SizedBox(width: 12),
+                Expanded(child: Text(item)),
+              ],
+            ),
           ),
-        ),
-        const Divider(height: 32),
-        SwitchListTile(
-          value: _matReady,
-          onChanged: (v) => setState(() => _matReady = v),
-          title: const Text('Matte bereitgelegt'),
-          subtitle: const Text('Sorge für eine rutschfeste, stabile Unterlage.'),
-        ),
-        SwitchListTile(
-          value: _timerSound,
-          onChanged: (v) => setState(() => _timerSound = v),
-          title: const Text('Timer-Sound aktiv'),
-          subtitle: const Text('Hörbare Signale helfen dir bei den Phasenwechseln.'),
-        ),
-        SwitchListTile(
-          value: _musicOff,
-          onChanged: (v) => setState(() => _musicOff = v),
-          title: const Text('Musik aus / Fokusmodus'),
-          subtitle: const Text('Minimiere Ablenkung für präzise Bewegungen.'),
         ),
         const Spacer(),
         SizedBox(
           width: double.infinity,
-          child: ElevatedButton(
-            onPressed: _checkStates.values.every((v) => v) && _matReady && _timerSound && _musicOff
-                ? () {
-                    setState(() {
-                      _didComplete = false;
-                    });
-                    controller.beginDelay();
-                  }
-                : null,
-            child: const Text('Übung starten'),
+          child: FilledButton.icon(
+            icon: const Icon(Icons.play_arrow_rounded),
+            label: const Text('Übung starten'),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+            onPressed: () {
+              setState(() {
+                _didComplete = false;
+              });
+              controller.beginDelay();
+            },
           ),
         ),
       ],

--- a/lib/features/training/moro/pre_check_screen.dart
+++ b/lib/features/training/moro/pre_check_screen.dart
@@ -17,41 +17,36 @@ class MoroPreCheckScreen extends StatefulWidget {
   State<MoroPreCheckScreen> createState() => _MoroPreCheckScreenState();
 }
 
-class _ChecklistItem {
-  const _ChecklistItem(this.label, {this.tooltip});
-
-  final String label;
-  final String? tooltip;
-}
-
 class _MoroPreCheckScreenState extends State<MoroPreCheckScreen> {
   static const _checklistItems = [
-    _ChecklistItem('Ich bin nüchtern oder habe höchstens einen leichten Snack gegessen.'),
-    _ChecklistItem('Ich trage lockere Kleidung und habe ausreichend Platz für das Training.'),
-    _ChecklistItem('Ich habe Wasser bereitgestellt.'),
-    _ChecklistItem(
+    (
+      'Ich bin nüchtern oder habe höchstens einen leichten Snack gegessen.',
+      null,
+    ),
+    (
+      'Ich trage lockere Kleidung und habe ausreichend Platz für das Training.',
+      null,
+    ),
+    (
+      'Ich habe Wasser bereitgestellt.',
+      null,
+    ),
+    (
       'Optional: Ich habe eine binaurale Musikspur vorbereitet (empfohlen).',
-      tooltip: 'Binaurale Musik kann die Konzentration unterstützen, ist aber nicht verpflichtend.',
+      'Binaurale Musik kann die Konzentration unterstützen, ist aber nicht verpflichtend.',
     ),
-    _ChecklistItem(
+    (
       'Optional: Ich habe meine eigene Musik oder Playlist vorbereitet.',
-      tooltip: 'Falls gewünscht, kannst du mit deiner eigenen Musik trainieren.',
+      'Falls gewünscht, kannst du mit deiner eigenen Musik trainieren.',
     ),
-    _ChecklistItem(
+    (
       'Optional: Ich kenne den Autoplay-Modus – die Übungen wechseln automatisch nach der Pause.',
-      tooltip: 'Der Autoplay-Modus kann jederzeit während des Trainings angepasst werden.',
+      'Der Autoplay-Modus kann jederzeit während des Trainings angepasst werden.',
     ),
   ];
 
-  late final List<bool> _checkItems;
   bool _autoplay = true;
   int _delay = 3;
-
-  @override
-  void initState() {
-    super.initState();
-    _checkItems = List<bool>.filled(_checklistItems.length, false);
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -67,19 +62,22 @@ class _MoroPreCheckScreenState extends State<MoroPreCheckScreen> {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 12),
-            ..._checklistItems.asMap().entries.map((entry) {
-              return CheckboxListTile(
-                value: _checkItems[entry.key],
-                onChanged: (v) => setState(() => _checkItems[entry.key] = v ?? false),
-                title: Text(entry.value.label),
-                secondary: entry.value.tooltip == null
-                    ? null
-                    : Tooltip(
-                        message: entry.value.tooltip!,
-                        child: const Icon(Icons.info_outline),
-                      ),
-              );
-            }),
+            ..._checklistItems.map(
+              (entry) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.info_outline_rounded),
+                  title: Text(entry.$1),
+                  trailing: entry.$2 == null
+                      ? null
+                      : Tooltip(
+                          message: entry.$2!,
+                          child: const Icon(Icons.help_outline),
+                        ),
+                ),
+              ),
+            ),
             const Divider(height: 32),
             SwitchListTile.adaptive(
               value: _autoplay,
@@ -111,16 +109,18 @@ class _MoroPreCheckScreenState extends State<MoroPreCheckScreen> {
             const Spacer(),
             SizedBox(
               width: double.infinity,
-              child: ElevatedButton(
-                onPressed: _checkItems.every((v) => v)
-                    ? () => Navigator.of(context).pop(
-                          MoroPreCheckResult(
-                            autoplayEnabled: _autoplay,
-                            autoplayDelaySeconds: _delay,
-                          ),
-                        )
-                    : null,
-                child: const Text('Weiter zum Training'),
+              child: FilledButton.icon(
+                icon: const Icon(Icons.arrow_forward_rounded),
+                label: const Text('Weiter zum Training'),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                onPressed: () => Navigator.of(context).pop(
+                  MoroPreCheckResult(
+                    autoplayEnabled: _autoplay,
+                    autoplayDelaySeconds: _delay,
+                  ),
+                ),
               ),
             ),
           ],

--- a/test/features/training/moro/moro_pre_check_screen_test.dart
+++ b/test/features/training/moro/moro_pre_check_screen_test.dart
@@ -3,30 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets(
-    'Weiter zum Training ist erst aktiv, wenn alle Vorbereitungspunkte bestätigt sind',
-    (tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: MoroPreCheckScreen(),
-        ),
-      );
+  testWidgets('Weiter zum Training ist direkt verfügbar', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: MoroPreCheckScreen(),
+      ),
+    );
 
-      final buttonFinder = find.widgetWithText(ElevatedButton, 'Weiter zum Training');
+    expect(find.byType(CheckboxListTile), findsNothing);
 
-      ElevatedButton button = tester.widget(buttonFinder);
-      expect(button.onPressed, isNull);
+    final buttonFinder = find.widgetWithText(FilledButton, 'Weiter zum Training');
+    final button = tester.widget<FilledButton>(buttonFinder);
 
-      final checklistFinder = find.byType(CheckboxListTile);
-      final itemCount = checklistFinder.evaluate().length;
-
-      for (var index = 0; index < itemCount; index++) {
-        await tester.tap(checklistFinder.at(index));
-        await tester.pumpAndSettle();
-      }
-
-      button = tester.widget(buttonFinder);
-      expect(button.onPressed, isNotNull);
-    },
-  );
+    expect(button.onPressed, isNotNull);
+  });
 }


### PR DESCRIPTION
## Summary
- replace the Moro training pre-check checkboxes with informational list tiles and keep the continue action always available
- streamline the exercise preparation stage by removing mandatory toggles and surfacing a prominent start button
- update the widget test to reflect the immediate availability of the training button

## Testing
- flutter test test/features/training/moro *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_690722aeba58832d9bc3edb95482ab7a