### PR TITLE
Add manual controls and navigation to Moro exercises

### DIFF
--- a/lib/features/training/moro/moro_exercise_screen.dart
+++ b/lib/features/training/moro/moro_exercise_screen.dart
@@ -33,6 +33,7 @@ class MoroExerciseResult {
   final int? tension;
   final int? pain;
   final String? notes;
+  final bool jumpToNextIntro;
 
   const MoroExerciseResult({
     required this.completed,
@@ -44,6 +45,7 @@ class MoroExerciseResult {
     this.tension,
     this.pain,
     this.notes,
+    this.jumpToNextIntro = false,
   });
 }
 
@@ -163,6 +165,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         autoplayDelaySeconds: widget.autoplayDelaySeconds,
         exerciseIndex: widget.exercise.index,
         hasNextExercise: widget.exercise.index < widget.totalExercises,
+        jumpToNextIntro: false,
       ),
     );
   }
@@ -189,6 +192,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         tension: entry.tension,
         pain: entry.pain,
         notes: entry.notes,
+        jumpToNextIntro: false,
       ),
     );
   }
@@ -203,6 +207,8 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
         return _buildActive(controller);
       case MoroSessionStage.pause:
         return _buildPause(controller);
+      case MoroSessionStage.manualPause:
+        return _buildManualPause(controller);
       case MoroSessionStage.cooldown:
         return _buildCooldown(controller);
       case MoroSessionStage.log:
@@ -431,6 +437,23 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
     );
   }
 
+  Widget _buildManualPause(MoroSessionController controller) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Pausiert', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 12),
+        const Text('Countdown und Timer sind angehalten.'),
+        const SizedBox(height: 12),
+        _buildInfoBanner(
+          Icons.access_time_outlined,
+          'Tippe auf „Weiter“, um an derselben Stelle fortzufahren.',
+        ),
+        const Spacer(),
+      ],
+    );
+  }
+
   Widget _buildCooldown(MoroSessionController controller) {
     final duration = controller.sessionDuration;
     if (!_didComplete) {
@@ -517,6 +540,7 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
                 exerciseIndex: widget.exercise.index,
                 hasNextExercise: widget.exercise.index < widget.totalExercises,
                 duration: _controller?.sessionDuration,
+                jumpToNextIntro: false,
               ),
             );
           },
@@ -641,6 +665,66 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
     return minutes > 0 ? '$minutes:$seconds min' : '$seconds s';
   }
 
+  void _handleNextIntro() {
+    final controller = _controller;
+    if (controller == null) return;
+    controller.abort();
+    setState(() {
+      _didComplete = false;
+    });
+    context.read<SessionNotifier>().clearResumePoint(widget.exercise.resumeKey);
+    Navigator.of(context).maybePop(
+      MoroExerciseResult(
+        completed: false,
+        autoplayEnabled: widget.autoplay,
+        autoplayDelaySeconds: widget.autoplayDelaySeconds,
+        exerciseIndex: widget.exercise.index,
+        hasNextExercise: widget.exercise.index < widget.totalExercises,
+        jumpToNextIntro: true,
+      ),
+    );
+  }
+
+  Widget _buildControlBar(MoroSessionController controller) {
+    final stage = controller.stage;
+    final canPause = stage == MoroSessionStage.active ||
+        stage == MoroSessionStage.delay ||
+        stage == MoroSessionStage.manualPause;
+    final isPaused = controller.isManuallyPaused;
+    final hasNext = widget.exercise.index < widget.totalExercises;
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: [
+        FilledButton.icon(
+          icon: Icon(isPaused ? Icons.play_arrow_rounded : Icons.pause_rounded),
+          label: Text(isPaused ? 'Weiter' : 'Pause'),
+          onPressed: canPause
+              ? () {
+                  controller.toggleManualPause();
+                }
+              : null,
+        ),
+        OutlinedButton.icon(
+          icon: const Icon(Icons.restart_alt_rounded),
+          label: const Text('Neustart'),
+          onPressed: () {
+            controller.restart();
+            setState(() {
+              _didComplete = false;
+            });
+          },
+        ),
+        OutlinedButton.icon(
+          icon: const Icon(Icons.skip_next_rounded),
+          label: const Text('Nächste Seite'),
+          onPressed: hasNext ? _handleNextIntro : null,
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = _controller;
@@ -663,7 +747,14 @@ class _MoroExerciseScreenState extends State<MoroExerciseScreen> {
           padding: const EdgeInsets.all(24.0),
           child: controller == null
               ? const Center(child: CircularProgressIndicator())
-              : _buildStageContent(controller),
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildControlBar(controller),
+                    const SizedBox(height: 16),
+                    Expanded(child: _buildStageContent(controller)),
+                  ],
+                ),
         ),
       ),
     );

--- a/lib/features/training/moro/moro_session_controller.dart
+++ b/lib/features/training/moro/moro_session_controller.dart
@@ -5,7 +5,15 @@ import 'package:flutter/foundation.dart';
 import 'moro_models.dart';
 import 'timers.dart';
 
-enum MoroSessionStage { intro, delay, active, pause, cooldown, log }
+enum MoroSessionStage {
+  intro,
+  delay,
+  active,
+  pause,
+  manualPause,
+  cooldown,
+  log,
+}
 
 class MoroSessionSnapshot {
   final MoroSessionStage stage;
@@ -54,6 +62,7 @@ class MoroSessionController extends ChangeNotifier {
   StreamSubscription? _timerSubscription;
   Timer? _delayTimer;
   Timer? _pauseTimer;
+  MoroSessionStage? _manualPauseSource;
 
   int _repeatIdx = 1;
   int _phaseIdx = 1;
@@ -77,6 +86,7 @@ class MoroSessionController extends ChangeNotifier {
   Duration get pauseRemaining => _pauseRemaining;
   Duration get sessionDuration => _sessionDuration;
   bool get isCompleted => _completed;
+  bool get isManuallyPaused => _stage == MoroSessionStage.manualPause;
 
   void startIntro() {
     _setStage(MoroSessionStage.intro);
@@ -86,6 +96,7 @@ class MoroSessionController extends ChangeNotifier {
     _cancelTimers();
     final delay = duration ?? const Duration(seconds: 3);
     _pauseRemaining = delay;
+    _manualPauseSource = null;
     _setStage(MoroSessionStage.delay);
     _delayTimer = Timer.periodic(const Duration(milliseconds: 250), (timer) {
       final ms = _pauseRemaining.inMilliseconds - 250;
@@ -105,6 +116,7 @@ class MoroSessionController extends ChangeNotifier {
 
   void startActive() {
     _cancelTimers();
+    _manualPauseSource = null;
     _setStage(MoroSessionStage.active);
     _repeatIdx = (_repeatIdx <= 0) ? 1 : _repeatIdx;
     _phaseIdx = (_phaseIdx <= 0) ? 1 : _phaseIdx;
@@ -178,6 +190,7 @@ class MoroSessionController extends ChangeNotifier {
   void skipToCooldown() {
     _cancelTimers();
     _completed = true;
+    _manualPauseSource = null;
     _setStage(MoroSessionStage.cooldown);
     _notifyResume(null);
   }
@@ -185,6 +198,7 @@ class MoroSessionController extends ChangeNotifier {
   void markLogged() {
     _setStage(MoroSessionStage.log);
     _completed = true;
+    _manualPauseSource = null;
     _notifyResume(null);
   }
 
@@ -192,6 +206,7 @@ class MoroSessionController extends ChangeNotifier {
     if (_stage == MoroSessionStage.pause) {
       _cancelPauseTimer();
       _pauseRemaining = Duration.zero;
+      _manualPauseSource = null;
       _setStage(MoroSessionStage.cooldown);
       _notifyResume(null);
     }
@@ -200,6 +215,32 @@ class MoroSessionController extends ChangeNotifier {
   void abort() {
     _cancelTimers();
     _completed = false;
+    _manualPauseSource = null;
+    _notifyResume(null);
+  }
+
+  bool toggleManualPause() {
+    if (_stage == MoroSessionStage.manualPause) {
+      _resumeFromManualPause();
+      return false;
+    }
+    if (_stage == MoroSessionStage.active || _stage == MoroSessionStage.delay) {
+      _enterManualPause();
+      return true;
+    }
+    return _stage == MoroSessionStage.manualPause;
+  }
+
+  void restart() {
+    _cancelTimers();
+    _manualPauseSource = null;
+    _repeatIdx = 1;
+    _phaseIdx = 1;
+    _remaining = Duration.zero;
+    _pauseRemaining = Duration.zero;
+    _sessionDuration = Duration.zero;
+    _completed = false;
+    startIntro();
     _notifyResume(null);
   }
 
@@ -270,13 +311,19 @@ class MoroSessionController extends ChangeNotifier {
         _stage == MoroSessionStage.intro) {
       return null;
     }
+    final effectiveStage =
+        _stage == MoroSessionStage.manualPause ? _manualPauseSource : _stage;
+    if (effectiveStage == null) {
+      return null;
+    }
+    final remainingMs = effectiveStage == MoroSessionStage.delay
+        ? _pauseRemaining.inMilliseconds
+        : _remaining.inMilliseconds;
     return MoroSessionSnapshot(
-      stage: _stage,
+      stage: effectiveStage,
       repeatIdx: _repeatIdx,
       phaseIdx: _phaseIdx,
-      remainingMilliseconds: _stage == MoroSessionStage.delay
-          ? _pauseRemaining.inMilliseconds
-          : _remaining.inMilliseconds,
+      remainingMilliseconds: remainingMs,
     );
   }
 
@@ -303,10 +350,41 @@ class MoroSessionController extends ChangeNotifier {
           _handleActiveCompleted();
         }
         break;
+      case MoroSessionStage.manualPause:
+        _manualPauseSource = MoroSessionStage.active;
+        _setStage(MoroSessionStage.manualPause);
+        break;
       case MoroSessionStage.cooldown:
       case MoroSessionStage.log:
       case MoroSessionStage.intro:
         _setStage(snapshot.stage);
+        break;
+    }
+  }
+
+  void _enterManualPause() {
+    _manualPauseSource = _stage;
+    _cancelTimers();
+    _setStage(MoroSessionStage.manualPause);
+    _notifyResume();
+  }
+
+  void _resumeFromManualPause() {
+    final source = _manualPauseSource;
+    if (source == null) {
+      beginDelay();
+      return;
+    }
+    _manualPauseSource = null;
+    switch (source) {
+      case MoroSessionStage.delay:
+        beginDelay(duration: _pauseRemaining);
+        break;
+      case MoroSessionStage.active:
+        startActive();
+        break;
+      default:
+        _setStage(source);
         break;
     }
   }

--- a/lib/features/training/moro/moro_training_screen.dart
+++ b/lib/features/training/moro/moro_training_screen.dart
@@ -397,6 +397,28 @@ class _MoroTrainingScreenState extends State<MoroTrainingScreen> {
     );
     if (!context.mounted) return;
     if (result is MoroExerciseResult) {
+      if (result.jumpToNextIntro && result.hasNextExercise) {
+        setState(() {
+          _autoplayEnabled = result.autoplayEnabled;
+          _autoplayDelaySeconds = result.autoplayDelaySeconds;
+        });
+        final nextIndex = ex.index + 1;
+        final nextExercise = allExercises.firstWhere(
+          (element) => element.index == nextIndex,
+          orElse: () => allExercises.last,
+        );
+        final nextOffset = await _getOffset(nextExercise.index);
+        if (!context.mounted) return;
+        await _openExercise(
+          context,
+          nextExercise,
+          nextOffset,
+          totalExercises,
+          allExercises,
+          source: _MoroExerciseLaunchSource.start,
+        );
+        return;
+      }
       if (result.completed) {
         context.read<SessionNotifier>().applyXpReward(xp: ex.xpReward);
         await MoroProgressStore.markCompleted(ex.index, totalExercises);


### PR DESCRIPTION
## Summary
- add a top control bar on the Moro exercise screen with pause/resume, restart, and next buttons
- extend the session controller to support manual pauses and restarting the current exercise
- let the training screen honour manual "next" navigation to the following exercise intro

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69072bb55318832da41833038d784163